### PR TITLE
Add ability to generate multiple CSS files

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ ENV.sassOptions =  {...}
 - `.outputFile`: the output CSS file, defaults to `app.css`
 - `.includePaths`: an array of include paths
 - `.sourceMap`: controls whether to generate sourceMaps, defaults to `true` in development. The sourceMap file will be saved to `options.outputFile + '.map'`
+- `.ext`: the extension to look for, defaults to `scss`
 - See [broccoli-sass](https://github.com/joliss/broccoli-sass) for a list of other supported options.
 
 ### Upgrading from a previous version

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
-var SassCompiler = require('broccoli-sass');
+var SassCompiler = require('broccoli-sass-source-maps');
 var path = require('path');
-var checker   = require('ember-cli-version-checker');
+var checker = require('ember-cli-version-checker');
+var mergeTrees = require('broccoli-merge-trees');
+var merge = require('merge');
 
 function SASSPlugin(options) {
   this.name = 'ember-cli-sass';
@@ -13,12 +15,23 @@ function SASSPlugin(options) {
   this.options = options;
 }
 
-SASSPlugin.prototype.toTree = function(tree, inputPath, outputPath) {
+SASSPlugin.prototype.toTree = function(tree, inputPath, outputPath, options) {
+  options = merge({}, this.options, options);
+
+  var paths = options.outputPaths;
+  var ext = options.ext || 'scss';
   var trees = [tree];
-  if (this.options.includePaths) trees = trees.concat(this.options.includePaths);
-  inputPath = path.join(inputPath, this.options.inputFile);
-  outputPath = path.join(outputPath, this.options.outputFile);
-  return new SassCompiler(trees, inputPath, outputPath, this.options);
+
+  if (options.includePaths) trees = trees.concat(options.includePaths);
+
+  trees = Object.keys(paths).map(function(file) {
+    var input = path.join(inputPath, file + '.' + ext);
+    var output = paths[file];
+
+    return new SassCompiler(trees, input, output, options);
+  });
+
+  return mergeTrees(trees);
 };
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-sass",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Use node-sass to preprocess your ember-cli app's files, with support for sourceMaps and include paths",
   "main": "index.js",
   "scripts": {
@@ -13,8 +13,10 @@
   "author": "@aexmachina",
   "license": "MIT",
   "dependencies": {
-    "broccoli-sass": "aexmachina/broccoli-sass#v0.4.x",
-    "ember-cli-version-checker": "^1.0.2"
+    "broccoli-merge-trees": "^0.2.1",
+    "broccoli-sass-source-maps": "^0.6.2",
+    "ember-cli-version-checker": "^1.0.2",
+    "merge": "^1.2.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Addresses [#28](https://github.com/aexmachina/ember-cli-sass/issues/28).

Tested with generating a single file, multiple files, including paths, and no customization at all.

Also, had an issue where the version my app was using is 3.1.1, but the repo seems to be at 3.1.0. Know of why this is?