### PR TITLE
Remove stray console.log

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,6 @@ SASSPlugin.prototype.toTree = function(tree, inputPath, outputPath, options) {
 
   if (options.includePaths) trees = trees.concat(options.includePaths);
 
-  console.log('paths', paths);
   trees = Object.keys(paths).map(function(file) {
     var input = path.join(inputPath, file + '.' + ext);
     var output = paths[file];


### PR DESCRIPTION
A `console.log` was added in the last release, I think unintentionally. This commit removes it.

Thank you for this plugin, it's really great :heart: :green_heart: :blue_heart: 