### PR TITLE
Remove useless ext configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ npm install --save-dev ember-cli-sass
 
 ## Usage
 
-By default this addon will compile `app/styles/app.scss` into `dist/assets/app.css` and produce 
+By default this addon will compile `app/styles/app.scss` or `app/styles/app.sass` into `dist/assets/app.css` and produce 
 a source map for your delectation.
 
 Or, if you want more control then you can specify options using the
@@ -22,7 +22,6 @@ ENV.sassOptions =  {...}
 
 - `.includePaths`: an array of include paths
 - `.sourceMap`: controls whether to generate sourceMaps, defaults to `true` in development. The sourceMap file will be saved to `options.outputFile + '.map'`
-- `.ext`: the extension to look for, defaults to `scss`
 - See [broccoli-sass](https://github.com/joliss/broccoli-sass) for a list of other supported options.
 
 ### Processing multiple files

--- a/index.js
+++ b/index.js
@@ -17,13 +17,12 @@ SASSPlugin.prototype.toTree = function(tree, inputPath, outputPath, options) {
   options = merge({}, this.options, options);
 
   var paths = options.outputPaths;
-  var ext = options.ext || 'scss';
   var trees = [tree];
 
   if (options.includePaths) trees = trees.concat(options.includePaths);
 
   trees = Object.keys(paths).map(function(file) {
-    var input = path.join(inputPath, file + '.' + ext);
+    var input = path.join(inputPath, file);
     var output = paths[file];
 
     return new SassCompiler(trees, input, output, options);


### PR DESCRIPTION
Hi,

I think the `ext` configuration is useless. By default sass builds `.scss` and `.sass`.

Remove the extension allows to build both without configuration.

Can you merge this fix with master too ?