### PR TITLE
Fix Foundation example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Specify some include paths in your Brocfile:
 
 ```javascript
 var app = new EmberApp({
-  sassOptions = {
+  sassOptions: {
     includePaths: [
       'bower_components/foundation/scss'
     ]


### PR DESCRIPTION
Allows the example to be copy/paste-able. It tripped me up for a moment! ;-)