### PR TITLE
Make toTree simple 

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,25 +17,14 @@ SASSPlugin.prototype.toTree = function(tree, inputPath, outputPath, inputOptions
   if (options.includePaths) {
     inputTrees = inputTrees.concat(options.includePaths);
   }
-  var trees = Object.keys(options.outputPaths).reduce(function(trees, file) {
-    var input;
-    if (options.extension) {
-      input = path.join('.', inputPath, file + '.' + options.extension);
-    }
-    else {
-      input = tryFile(file + '.scss') || tryFile(file + '.sass');
-    }
-    var output = options.outputPaths[file];
-    if (input) {
-      trees.push(new SassCompiler(inputTrees, input, output, options));
-    }
-    return trees;
-  }, []);
 
-  function tryFile(file) {
-    var filePath = path.join('.', inputPath, file);
-    return fs.existsSync(filePath) ? filePath : false;
-  }
+  var ext = options.extension || 'scss';
+  var paths = options.outputPaths;
+  var trees = Object.keys(paths).map(function(file) {
+    var input = path.join(inputPath, file + '.' + ext);
+    var output = paths[file];
+    return new SassCompiler(inputTrees, input, output, options);
+  });
 
   return mergeTrees(trees);
 };


### PR DESCRIPTION
Given the many issues(#56, #57, #67) because the `tryFile`, I'm make this pull request to propose a refactor in `toTree` method inspired in project like [ember-cli-less](https://github.com/gdub22/ember-cli-less).

I made some tests using https://github.com/ember-cli/ember-cli/pull/4825 and the issue(fixed with a hack in #56) still cause trouble because of the outputPath and inputPath is '/' exactly as commented in https://github.com/aexmachina/ember-cli-sass/issues/56#issuecomment-110055702. I was thinking why ember-cli-less works with addons and ember-cli-sass not, the tryFile is the problems here. I saw many comments by @aexmachina to users use `extension` config to fix problems with `tryFile`, so let's use this options as default value and never try to check if the files exists. I'm use this branch in my company now, and given we use here scss I don't need change any configuration. 

The pull request make my pull request #57 invalid and unnecessary, refactor the `toTree`, fix many issues about 'Error: File not found: ...' and close https://github.com/ember-cli/ember-cli/issues/4084
 

 