### PR TITLE
Change project name to match package name

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ SASSPlugin.prototype.toTree = function(tree, inputPath, outputPath, inputOptions
 };
 
 module.exports = {
-  name:  'Ember CLI SASS',
+  name:  'ember-cli-sass',
 
   shouldSetupRegistryInIncluded: function() {
     return !checker.isAbove(this, '0.2.0');


### PR DESCRIPTION
We just ran into an issue whilst trying to add node_module paths to sassOptions inside of an addon. 

```
var sassOptions = app.options.sassOptions || {};
    sassOptions.includePaths = sassOptions.includePaths || [];
    sassOptions.includePaths.push(this.addonPath('node_modules/foundation-apps/scss'));
    app.options.sassOptions = sassOptions;
    this._super.included(app);

    this.addons.forEach(function(addon){
      if (['ember-cli-sass'].indexOf(addon.name) > -1) {
        addon.included.apply(addon, [app]);
      }
    });
```

This *should* work. However the issue is the naming convention. ember-cli-sass is actually called EMBER CLI SASS which meant our sassOptions were never getting passed in!