### PR TITLE
Compile .sass and .scss out of the box

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ var app = new EmberApp({
 
 - `includePaths`: an array of include paths
 - `sourceMap`: controls whether to generate sourceMaps, defaults to `true` in development. The sourceMap file will be saved to `options.outputFile + '.map'`
-- `extension`: specifies the file extension for the input files, defaults to `scss`
+- `extensions`: specifies the file extensions for the input files, defaults to `['scss', 'sass']`
 - See [broccoli-sass-source-maps](https://github.com/aexmachina/broccoli-sass-source-maps) for a list of other supported options.
 
 ### Processing multiple files

--- a/index.js
+++ b/index.js
@@ -18,12 +18,17 @@ SASSPlugin.prototype.toTree = function(tree, inputPath, outputPath, inputOptions
     inputTrees = inputTrees.concat(options.includePaths);
   }
 
-  var ext = options.extension || 'scss';
+  var exts = options.extensions || ['scss', 'sass'];
   var paths = options.outputPaths;
-  var trees = Object.keys(paths).map(function(file) {
-    var input = path.join(inputPath, file + '.' + ext);
-    var output = paths[file];
-    return new SassCompiler(inputTrees, input, output, options);
+  var trees = [];
+  Object.keys(paths).forEach(function(file) {
+    exts.forEach(function(ext) {
+      var input = path.join(inputPath, file + '.' + ext);
+      if(fs.existsSync('.' + input)) {
+        var output = paths[file];
+        trees.push(new SassCompiler(inputTrees, input, output, options));
+      }
+    });
   });
 
   return mergeTrees(trees);


### PR DESCRIPTION
The library only compiles `app.scss` files by default. However, the documentation says it compiles both `app.scss` and `app.sass`. This PR adds support to compile both of them by default.