### PR TITLE
add ability to turn off watching for include_paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,20 @@ var app = new EmberApp({
 - `extension`: specifies the file extension for the input files, defaults to `scss`
 - See [broccoli-sass-source-maps](https://github.com/aexmachina/broccoli-sass-source-maps) for a list of other supported options.
 
+### Excluding include paths from watch
+
+If you add a large file tree to includePaths (e.g. node_modules), it may cause startup to slow or hang. To skip watching on an include_path, instead of specifying a string, specify an object with a `path` and a `noWatch` key:
+
+```
+var app = new EmberApp({
+  sassOptions: {
+    includePaths: [
+      { path: 'node_modules', noWatch: true }
+    ]
+  }
+});
+```
+
 ### Processing multiple files
 
 If you need to process multiple files, it can be done by [configuring the output paths](http://ember-cli.com/user-guide/#configuring-output-paths) in your `ember-cli-build.js`:

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var SassCompiler = require('broccoli-sass-source-maps');
 var path = require('path');
 var checker = require('ember-cli-version-checker');
+var UnwatchedTree = require('broccoli-unwatched-tree')
 var mergeTrees = require('broccoli-merge-trees');
 var merge = require('merge');
 var fs = require('fs');
@@ -16,7 +17,17 @@ SASSPlugin.prototype.toTree = function(tree, inputPath, outputPath, inputOptions
 
   var inputTrees = [tree];
   if (options.includePaths) {
-    inputTrees = inputTrees.concat(options.includePaths);
+    inputTrees = inputTrees.concat(options.includePaths.map(function(path) {
+      if (typeof path === 'object') {
+        if (!path.path) throw new Error('sassOptions includePaths must either be an object with a "path" key or a string.')
+        if (path.noWatch) {
+          path = UnwatchedTree(path.path)
+        } else {
+          path = path.path
+        }
+      }
+      return path
+    }));
   }
 
   var ext = options.extension || 'scss';

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "broccoli-merge-trees": "^1.1.0",
     "broccoli-sass-source-maps": "^1.4.0",
+    "broccoli-unwatched-tree": "^0.1.1",
     "ember-cli-version-checker": "^1.0.2",
     "merge": "^1.2.0"
   },


### PR DESCRIPTION
In other projects that use sass, I commonly add `node_modules` to my `include_paths`, so I can `@import` modules with files like `styles.scss` at the root, without naming conflicts or having to explicitly add each one to the config. (Libraries like bootstrap are a use case for this).

However, when trying to do this via this library, I encountered an (effectively) infinite hang when running `ember server`. I realized this was because it was attempting to watch the entire `node_modules` folder, which is undesirable.

I added the option to pass an object with a "noWatch" key to disable watching on an includePath, which resolves this issue for me.