### PR TITLE
Add option to use only app/styles and includePath

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ var app = new EmberApp({
 ```
 
 - `includePaths`: an array of include paths
+- `onlyIncluded`: true/false whether to use only what is in app/styles and includePaths. Helps with performance when using NPM linked modules
 - `sourceMap`: controls whether to generate sourceMaps, defaults to `true` in development. The sourceMap file will be saved to `options.outputFile + '.map'`
 - `extension`: specifies the file extension for the input files, defaults to `scss`. Set to `sass` if you want to use `.sass` instead.
 - `nodeSass`: Allows a different version of [node-sass](https://www.npmjs.com/package/node-sass) to be used (see below)

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var SassCompiler = require('broccoli-sass-source-maps');
 var path = require('path');
 var checker = require('ember-cli-version-checker');
+var Funnel = require('broccoli-funnel');
 var mergeTrees = require('broccoli-merge-trees');
 var merge = require('merge');
 var fs = require('fs');
@@ -13,8 +14,18 @@ function SASSPlugin(optionsFn) {
 
 SASSPlugin.prototype.toTree = function(tree, inputPath, outputPath, inputOptions) {
   var options = merge({}, this.optionsFn(), inputOptions);
+  var inputTrees;
 
-  var inputTrees = [tree];
+  if (options.onlyIncluded) {
+    inputTrees = [new Funnel('app/styles', {
+      srcDir: '/',
+      destDir: 'app/styles',
+      annotation: 'Funnel (styles)'
+    })];
+  } else {
+    inputTrees = [tree];
+  }
+
   if (options.includePaths) {
     inputTrees = inputTrees.concat(options.includePaths);
   }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   ],
   "dependencies": {
     "broccoli-merge-trees": "^1.1.0",
+    "broccoli-funnel": "^1.0.0",
     "broccoli-sass-source-maps": "^1.8.0",
     "ember-cli-babel": "5.1.10",
     "ember-cli-version-checker": "^1.0.2",


### PR DESCRIPTION
Putting this here for discussion as it can help with #74.

This PR adds a new option `onlyIncluded` which allows the user to prune the style tree down to just app/styles and anything in the `includePaths` array. This helps performance because the broccoli-caching-writer no longer has to stat everything in the addon trees (via walk-sync).  The speedup is especially pronounced when using linked modules because those trees can get very large.