### PR TITLE
upgrade broccoli-sass-source-maps to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "broccoli-merge-trees": "^1.1.0",
     "broccoli-funnel": "^1.0.0",
-    "broccoli-sass-source-maps": "^1.8.0",
+    "broccoli-sass-source-maps": "^2.0.0",
     "ember-cli-babel": "5.1.10",
     "ember-cli-version-checker": "^1.0.2",
     "merge": "^1.2.0"


### PR DESCRIPTION
broccoli-sass-source-maps dependencies requires node-sass ^3.8 and your new 2.0 version requires ^4.0, node-sass 4.1 introduced support for Linux Alpine which makes it possible to compiles smaller docker images for ember apps.