### PR TITLE
Keeping tree intact when using onlyIncluded flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,9 +17,8 @@ SASSPlugin.prototype.toTree = function(tree, inputPath, outputPath, inputOptions
   var inputTrees;
 
   if (options.onlyIncluded) {
-    inputTrees = [new Funnel('app/styles', {
-      srcDir: '/',
-      destDir: 'app/styles',
+    inputTrees = [new Funnel(tree, {
+      include: ['app/styles/**/*'],
       annotation: 'Funnel (styles)'
     })];
   }


### PR DESCRIPTION
The `onlyIncluded` flag seems to be ignoring the existing tree, which makes it impossible to include pod styles or anything that is dynamically created in the build process.

Using the existing tree allows me to include sass files that were dynamically created without losing the performance benefit of only compiling `app/styles` and explicitly defined node/bower modules.

This modifies the previous PR of #140, and fixes ebryn/ember-component-css#203

(Thanks to @webark for the proposed fix)
 