### PR TITLE
Don't pin `ember-cli-babel` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "broccoli-funnel": "^1.0.0",
     "broccoli-merge-trees": "^1.1.0",
     "broccoli-sass-source-maps": "^2.0.0",
-    "ember-cli-babel": "5.1.10",
+    "ember-cli-babel": "^5.1.10",
     "ember-cli-version-checker": "^1.0.2",
     "merge": "^1.2.0"
   },


### PR DESCRIPTION
Is there any reason it's pinned at `5.1.10`?