### PR TITLE
Remove babel from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "broccoli-clean-css": "^1.1.0",
     "ember-cli": "2.7.0",
     "ember-cli-app-version": "^1.0.0",
+    "ember-cli-babel": "^5.1.10",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-foundation-6-sass": "0.0.17",
     "ember-cli-htmlbars": "^1.0.3",
@@ -50,7 +51,6 @@
     "broccoli-funnel": "^1.0.0",
     "broccoli-merge-trees": "^1.1.0",
     "broccoli-sass-source-maps": "^2.0.0",
-    "ember-cli-babel": "^5.1.10",
     "ember-cli-version-checker": "^1.0.2",
     "merge": "^1.2.0"
   },


### PR DESCRIPTION
It's not really needed and will cause it to be installed multiple times once `ember-cli-babel` hits version 6.