### PR TITLE
Updates version-checker & foundation-6-sass dependencies, related syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 /* eslint-env node */
 var SassCompiler = require('broccoli-sass-source-maps');
 var path = require('path');
-var checker = require('ember-cli-version-checker');
+var VersionChecker = require('ember-cli-version-checker');
 var Funnel = require('broccoli-funnel');
 var mergeTrees = require('broccoli-merge-trees');
 var fs = require('fs');
@@ -45,7 +45,10 @@ module.exports = {
   name:  'ember-cli-sass',
 
   shouldSetupRegistryInIncluded: function() {
-    return !checker.isAbove(this, '0.2.0');
+    var checker = new VersionChecker(this);
+    var dep = checker.for('ember-cli');
+
+    return !dep.isAbove('0.2.0');
   },
 
   sassOptions: function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-sass",
-  "version": "7.1.2",
+  "version": "7.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -179,6 +179,7 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-0.0.7.tgz",
       "integrity": "sha1-gUMBrf6KLxCfboTV6TUZbvtmlhU=",
+      "dev": true,
       "requires": {
         "ensure-posix-path": "https://registry.npmjs.org/ensure-posix-path/-/ensure-posix-path-1.0.2.tgz"
       }
@@ -343,6 +344,7 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
       "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+      "dev": true,
       "requires": {
         "lodash": "4.17.4"
       },
@@ -350,7 +352,210 @@
         "lodash": {
           "version": "4.17.4",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        }
+      }
+    },
+    "async-disk-cache": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.3.3.tgz",
+      "integrity": "sha512-GyaWSbDAZCltxSobtj1m1ptXa0+zSdjWs3sM4IqnvhoRwMDHW5786sXQ1RiXbR3ZGuQe6NXMB4N0vUmW163cew==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "heimdalljs": "0.2.5",
+        "istextorbinary": "2.1.0",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2",
+        "rsvp": "3.6.2",
+        "username-sync": "1.0.1"
+      },
+      "dependencies": {
+        "balanced-match": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "dev": true
+        },
+        "binaryextensions": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.0.0.tgz",
+          "integrity": "sha1-5ZfRp6ajVYotHHJBoWyZll5qpA8=",
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+          "dev": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "editions": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.3.tgz",
+          "integrity": "sha1-CQcQG92iD6w8vjNMJ8vQaI3Jmls=",
+          "dev": true
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "heimdalljs": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.2.5.tgz",
+          "integrity": "sha1-aqVDCO7nk7ZCz/nPlHgURfN3MKw=",
+          "dev": true,
+          "requires": {
+            "rsvp": "3.2.1"
+          },
+          "dependencies": {
+            "rsvp": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
+              "integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo=",
+              "dev": true
+            }
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        },
+        "istextorbinary": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.1.0.tgz",
+          "integrity": "sha1-2+0qb1G+L3R1to+JRlgRFBt1iHQ=",
+          "dev": true,
+          "requires": {
+            "binaryextensions": "2.0.0",
+            "editions": "1.3.3",
+            "textextensions": "2.1.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "rsvp": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+          "dev": true
+        },
+        "textextensions": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.1.0.tgz",
+          "integrity": "sha1-G+DcKg3CRNRL6KCa9qha+5PE28M=",
+          "dev": true
+        },
+        "username-sync": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/username-sync/-/username-sync-1.0.1.tgz",
+          "integrity": "sha1-HN6H7vz5S4gimE2Ti6K3l0Jtrh8=",
+          "dev": true
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "dev": true
         }
       }
     },
@@ -368,6 +573,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/async-promise-queue/-/async-promise-queue-1.0.4.tgz",
       "integrity": "sha512-GQ5X3DT+TefYuFPHdvIPXFTlKnh39U7dwtl+aUBGeKjMea9nBpv3c91DXgeyBQmY07vQ97f3Sr9XHqkamEameQ==",
+      "dev": true,
       "requires": {
         "async": "2.6.0",
         "debug": "2.6.9"
@@ -377,6 +583,7 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
           "requires": {
             "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
           }
@@ -410,10 +617,374 @@
         }
       }
     },
+    "babel-core": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
+      "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "babel-generator": "6.26.0",
+        "babel-helpers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-register": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "convert-source-map": "1.5.1",
+        "debug": "2.6.9",
+        "json5": "0.5.1",
+        "lodash": "4.17.4",
+        "minimatch": "3.0.4",
+        "path-is-absolute": "1.0.1",
+        "private": "0.1.8",
+        "slash": "1.0.0",
+        "source-map": "0.5.7"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "babel-code-frame": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+          "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.2"
+          }
+        },
+        "babel-helpers": {
+          "version": "6.24.1",
+          "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+          "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0"
+          }
+        },
+        "babel-messages": {
+          "version": "6.23.0",
+          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+          "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-runtime": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
+          "requires": {
+            "core-js": "2.5.3",
+            "regenerator-runtime": "0.11.1"
+          }
+        },
+        "babel-template": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+          "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-traverse": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+          "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "debug": "2.6.9",
+            "globals": "9.18.0",
+            "invariant": "2.2.2",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-types": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+          "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "esutils": "2.0.2",
+            "lodash": "4.17.4",
+            "to-fast-properties": "1.0.3"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+          "dev": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+          "dev": true
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "invariant": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+          "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+          "dev": true,
+          "requires": {
+            "loose-envify": "1.3.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+          "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+          "dev": true,
+          "requires": {
+            "js-tokens": "3.0.2"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+          "dev": true
+        },
+        "slash": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+          "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        },
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+          "dev": true
+        }
+      }
+    },
+    "babel-generator": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
+      "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
+      "dev": true,
+      "requires": {
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "detect-indent": "4.0.0",
+        "jsesc": "1.3.0",
+        "lodash": "4.17.4",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
+      },
+      "dependencies": {
+        "babel-messages": {
+          "version": "6.23.0",
+          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+          "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-runtime": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
+          "requires": {
+            "core-js": "2.5.3",
+            "regenerator-runtime": "0.11.1"
+          }
+        },
+        "babel-types": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+          "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "esutils": "2.0.2",
+            "lodash": "4.17.4",
+            "to-fast-properties": "1.0.3"
+          }
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+          "dev": true
+        },
+        "jsesc": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        },
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+          "dev": true
+        },
+        "trim-right": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+          "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+          "dev": true
+        }
+      }
+    },
     "babel-helper-builder-binary-assignment-operator-visitor": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+      "dev": true,
       "requires": {
         "babel-helper-explode-assignable-expression": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -424,6 +995,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
           "requires": {
             "core-js": "2.5.1",
             "regenerator-runtime": "0.11.0"
@@ -433,6 +1005,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
           "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+          "dev": true,
           "requires": {
             "babel-runtime": "6.26.0",
             "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
@@ -443,17 +1016,20 @@
         "core-js": {
           "version": "2.5.1",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+          "dev": true
         },
         "lodash": {
           "version": "4.17.4",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
         },
         "regenerator-runtime": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+          "dev": true
         }
       }
     },
@@ -481,6 +1057,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-traverse": "6.26.0",
@@ -491,6 +1068,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
           "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+          "dev": true,
           "requires": {
             "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
             "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
@@ -501,6 +1079,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
           "requires": {
             "core-js": "2.5.1",
             "regenerator-runtime": "0.11.0"
@@ -510,6 +1089,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
           "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+          "dev": true,
           "requires": {
             "babel-code-frame": "6.26.0",
             "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
@@ -526,6 +1106,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
           "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+          "dev": true,
           "requires": {
             "babel-runtime": "6.26.0",
             "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
@@ -536,17 +1117,20 @@
         "babylon": {
           "version": "6.18.0",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+          "dev": true
         },
         "core-js": {
           "version": "2.5.1",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+          "dev": true
         },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
           "requires": {
             "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
           }
@@ -554,22 +1138,26 @@
         "globals": {
           "version": "9.18.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+          "dev": true
         },
         "js-tokens": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+          "dev": true
         },
         "lodash": {
           "version": "4.17.4",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
         },
         "regenerator-runtime": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+          "dev": true
         }
       }
     },
@@ -612,6 +1200,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
@@ -622,6 +1211,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
           "requires": {
             "core-js": "2.5.1",
             "regenerator-runtime": "0.11.0"
@@ -631,6 +1221,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
           "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+          "dev": true,
           "requires": {
             "babel-runtime": "6.26.0",
             "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
@@ -641,17 +1232,20 @@
         "core-js": {
           "version": "2.5.1",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+          "dev": true
         },
         "lodash": {
           "version": "4.17.4",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
         },
         "regenerator-runtime": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+          "dev": true
         }
       }
     },
@@ -659,6 +1253,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+      "dev": true,
       "requires": {
         "babel-helper-function-name": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
         "babel-runtime": "6.26.0",
@@ -671,6 +1266,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
           "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+          "dev": true,
           "requires": {
             "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
             "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
@@ -681,6 +1277,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
           "requires": {
             "core-js": "2.5.1",
             "regenerator-runtime": "0.11.0"
@@ -690,6 +1287,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
           "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+          "dev": true,
           "requires": {
             "babel-runtime": "6.26.0",
             "babel-traverse": "6.26.0",
@@ -702,6 +1300,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
           "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+          "dev": true,
           "requires": {
             "babel-code-frame": "6.26.0",
             "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
@@ -718,6 +1317,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
           "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+          "dev": true,
           "requires": {
             "babel-runtime": "6.26.0",
             "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
@@ -728,17 +1328,20 @@
         "babylon": {
           "version": "6.18.0",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+          "dev": true
         },
         "core-js": {
           "version": "2.5.1",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+          "dev": true
         },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
           "requires": {
             "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
           }
@@ -746,22 +1349,26 @@
         "globals": {
           "version": "9.18.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+          "dev": true
         },
         "js-tokens": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+          "dev": true
         },
         "lodash": {
           "version": "4.17.4",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
         },
         "regenerator-runtime": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+          "dev": true
         }
       }
     },
@@ -796,6 +1403,7 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       },
@@ -804,6 +1412,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
           "requires": {
             "core-js": "2.5.1",
             "regenerator-runtime": "0.11.0"
@@ -812,12 +1421,14 @@
         "core-js": {
           "version": "2.5.1",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+          "dev": true
         },
         "regenerator-runtime": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+          "dev": true
         }
       }
     },
@@ -825,6 +1436,7 @@
       "version": "0.1.11",
       "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.1.11.tgz",
       "integrity": "sha512-hZw5qNNGAR02Y+yBUrtsnJHh8OXavkayPRqKGAXnIm4t5rWVpj3ArwsC7TWdpZsBguQvHAeyTxZ7s23yY60HHg==",
+      "dev": true,
       "requires": {
         "semver": "5.4.1"
       },
@@ -832,7 +1444,8 @@
         "semver": {
           "version": "5.4.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+          "dev": true
         }
       }
     },
@@ -840,29 +1453,40 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.2.1.tgz",
       "integrity": "sha1-5j+QzDxxzGs7aftRtPYDEtbPc0w=",
+      "dev": true,
       "requires": {
         "ember-rfc176-data": "0.3.1"
       }
     },
+    "babel-plugin-htmlbars-inline-precompile": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-0.2.3.tgz",
+      "integrity": "sha1-zTZeJ4r0Cb+mvncExDVL7udCRGs=",
+      "dev": true
+    },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
+      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+      "dev": true
     },
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
+      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+      "dev": true
     },
     "babel-plugin-syntax-trailing-function-commas": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
+      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+      "dev": true
     },
     "babel-plugin-transform-async-to-generator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+      "dev": true,
       "requires": {
         "babel-helper-remap-async-to-generator": "6.24.1",
         "babel-plugin-syntax-async-functions": "6.13.0",
@@ -873,6 +1497,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
           "requires": {
             "core-js": "2.5.1",
             "regenerator-runtime": "0.11.0"
@@ -881,12 +1506,14 @@
         "core-js": {
           "version": "2.5.1",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+          "dev": true
         },
         "regenerator-runtime": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+          "dev": true
         }
       }
     },
@@ -902,6 +1529,205 @@
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "requires": {
         "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+      }
+    },
+    "babel-plugin-transform-es2015-block-scoping": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+      "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.4"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "babel-code-frame": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+          "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.2"
+          }
+        },
+        "babel-messages": {
+          "version": "6.23.0",
+          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+          "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-runtime": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
+          "requires": {
+            "core-js": "2.5.3",
+            "regenerator-runtime": "0.11.1"
+          }
+        },
+        "babel-template": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+          "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-traverse": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+          "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "debug": "2.6.9",
+            "globals": "9.18.0",
+            "invariant": "2.2.2",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-types": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+          "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "esutils": "2.0.2",
+            "lodash": "4.17.4",
+            "to-fast-properties": "1.0.3"
+          }
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+          "dev": true
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "invariant": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+          "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+          "dev": true,
+          "requires": {
+            "loose-envify": "1.3.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+          "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+          "dev": true,
+          "requires": {
+            "js-tokens": "3.0.2"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        },
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+          "dev": true
+        }
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -923,6 +1749,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-template": "6.26.0"
@@ -932,6 +1759,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
           "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+          "dev": true,
           "requires": {
             "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
             "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
@@ -942,6 +1770,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
           "requires": {
             "core-js": "2.5.1",
             "regenerator-runtime": "0.11.0"
@@ -951,6 +1780,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
           "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+          "dev": true,
           "requires": {
             "babel-runtime": "6.26.0",
             "babel-traverse": "6.26.0",
@@ -963,6 +1793,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
           "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+          "dev": true,
           "requires": {
             "babel-code-frame": "6.26.0",
             "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
@@ -979,6 +1810,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
           "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+          "dev": true,
           "requires": {
             "babel-runtime": "6.26.0",
             "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
@@ -989,17 +1821,20 @@
         "babylon": {
           "version": "6.18.0",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+          "dev": true
         },
         "core-js": {
           "version": "2.5.1",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+          "dev": true
         },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
           "requires": {
             "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
           }
@@ -1007,22 +1842,26 @@
         "globals": {
           "version": "9.18.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+          "dev": true
         },
         "js-tokens": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+          "dev": true
         },
         "lodash": {
           "version": "4.17.4",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
         },
         "regenerator-runtime": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+          "dev": true
         }
       }
     },
@@ -1037,6 +1876,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0"
@@ -1046,6 +1886,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
           "requires": {
             "core-js": "2.5.1",
             "regenerator-runtime": "0.11.0"
@@ -1055,6 +1896,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
           "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+          "dev": true,
           "requires": {
             "babel-runtime": "6.26.0",
             "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
@@ -1065,17 +1907,20 @@
         "core-js": {
           "version": "2.5.1",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+          "dev": true
         },
         "lodash": {
           "version": "4.17.4",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
         },
         "regenerator-runtime": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+          "dev": true
         }
       }
     },
@@ -1083,6 +1928,7 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       },
@@ -1091,6 +1937,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
           "requires": {
             "core-js": "2.5.1",
             "regenerator-runtime": "0.11.0"
@@ -1099,12 +1946,14 @@
         "core-js": {
           "version": "2.5.1",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+          "dev": true
         },
         "regenerator-runtime": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+          "dev": true
         }
       }
     },
@@ -1112,6 +1961,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+      "dev": true,
       "requires": {
         "babel-helper-function-name": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
         "babel-runtime": "6.26.0",
@@ -1122,6 +1972,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
           "requires": {
             "core-js": "2.5.1",
             "regenerator-runtime": "0.11.0"
@@ -1131,6 +1982,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
           "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+          "dev": true,
           "requires": {
             "babel-runtime": "6.26.0",
             "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
@@ -1141,17 +1993,20 @@
         "core-js": {
           "version": "2.5.1",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+          "dev": true
         },
         "lodash": {
           "version": "4.17.4",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
         },
         "regenerator-runtime": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+          "dev": true
         }
       }
     },
@@ -1159,6 +2014,7 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       },
@@ -1167,6 +2023,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
           "requires": {
             "core-js": "2.5.1",
             "regenerator-runtime": "0.11.0"
@@ -1175,12 +2032,14 @@
         "core-js": {
           "version": "2.5.1",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+          "dev": true
         },
         "regenerator-runtime": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+          "dev": true
         }
       }
     },
@@ -1188,6 +2047,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+      "dev": true,
       "requires": {
         "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
         "babel-runtime": "6.26.0",
@@ -1198,6 +2058,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
           "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+          "dev": true,
           "requires": {
             "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
             "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
@@ -1208,6 +2069,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
           "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
+          "dev": true,
           "requires": {
             "babel-plugin-transform-strict-mode": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
             "babel-runtime": "6.26.0",
@@ -1219,6 +2081,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
           "requires": {
             "core-js": "2.5.1",
             "regenerator-runtime": "0.11.0"
@@ -1228,6 +2091,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
           "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+          "dev": true,
           "requires": {
             "babel-runtime": "6.26.0",
             "babel-traverse": "6.26.0",
@@ -1240,6 +2104,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
           "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+          "dev": true,
           "requires": {
             "babel-code-frame": "6.26.0",
             "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
@@ -1256,6 +2121,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
           "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+          "dev": true,
           "requires": {
             "babel-runtime": "6.26.0",
             "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
@@ -1266,17 +2132,20 @@
         "babylon": {
           "version": "6.18.0",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+          "dev": true
         },
         "core-js": {
           "version": "2.5.1",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+          "dev": true
         },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
           "requires": {
             "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
           }
@@ -1284,22 +2153,234 @@
         "globals": {
           "version": "9.18.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+          "dev": true
         },
         "js-tokens": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+          "dev": true
         },
         "lodash": {
           "version": "4.17.4",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
         },
         "regenerator-runtime": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+          "dev": true
+        }
+      }
+    },
+    "babel-plugin-transform-es2015-modules-commonjs": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
+      "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-strict-mode": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-types": "6.26.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "babel-code-frame": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+          "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.2"
+          }
+        },
+        "babel-messages": {
+          "version": "6.23.0",
+          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+          "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "babel-plugin-transform-strict-mode": {
+          "version": "6.24.1",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+          "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0"
+          }
+        },
+        "babel-runtime": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
+          "requires": {
+            "core-js": "2.5.3",
+            "regenerator-runtime": "0.11.1"
+          }
+        },
+        "babel-template": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+          "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-traverse": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+          "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "debug": "2.6.9",
+            "globals": "9.18.0",
+            "invariant": "2.2.2",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-types": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+          "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "esutils": "2.0.2",
+            "lodash": "4.17.4",
+            "to-fast-properties": "1.0.3"
+          }
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+          "dev": true
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "invariant": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+          "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+          "dev": true,
+          "requires": {
+            "loose-envify": "1.3.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+          "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+          "dev": true,
+          "requires": {
+            "js-tokens": "3.0.2"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        },
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+          "dev": true
         }
       }
     },
@@ -1307,6 +2388,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+      "dev": true,
       "requires": {
         "babel-helper-hoist-variables": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
         "babel-runtime": "6.26.0",
@@ -1317,6 +2399,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
           "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+          "dev": true,
           "requires": {
             "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
             "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
@@ -1327,6 +2410,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
           "requires": {
             "core-js": "2.5.1",
             "regenerator-runtime": "0.11.0"
@@ -1336,6 +2420,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
           "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+          "dev": true,
           "requires": {
             "babel-runtime": "6.26.0",
             "babel-traverse": "6.26.0",
@@ -1348,6 +2433,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
           "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+          "dev": true,
           "requires": {
             "babel-code-frame": "6.26.0",
             "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
@@ -1364,6 +2450,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
           "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+          "dev": true,
           "requires": {
             "babel-runtime": "6.26.0",
             "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
@@ -1374,17 +2461,20 @@
         "babylon": {
           "version": "6.18.0",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+          "dev": true
         },
         "core-js": {
           "version": "2.5.1",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+          "dev": true
         },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
           "requires": {
             "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
           }
@@ -1392,22 +2482,26 @@
         "globals": {
           "version": "9.18.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+          "dev": true
         },
         "js-tokens": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+          "dev": true
         },
         "lodash": {
           "version": "4.17.4",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
         },
         "regenerator-runtime": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+          "dev": true
         }
       }
     },
@@ -1415,6 +2509,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+      "dev": true,
       "requires": {
         "babel-plugin-transform-es2015-modules-amd": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -1425,6 +2520,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
           "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+          "dev": true,
           "requires": {
             "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
             "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
@@ -1435,6 +2531,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
           "requires": {
             "core-js": "2.5.1",
             "regenerator-runtime": "0.11.0"
@@ -1444,6 +2541,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
           "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+          "dev": true,
           "requires": {
             "babel-runtime": "6.26.0",
             "babel-traverse": "6.26.0",
@@ -1456,6 +2554,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
           "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+          "dev": true,
           "requires": {
             "babel-code-frame": "6.26.0",
             "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
@@ -1472,6 +2571,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
           "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+          "dev": true,
           "requires": {
             "babel-runtime": "6.26.0",
             "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
@@ -1482,17 +2582,20 @@
         "babylon": {
           "version": "6.18.0",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+          "dev": true
         },
         "core-js": {
           "version": "2.5.1",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+          "dev": true
         },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
           "requires": {
             "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
           }
@@ -1500,22 +2603,26 @@
         "globals": {
           "version": "9.18.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+          "dev": true
         },
         "js-tokens": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+          "dev": true
         },
         "lodash": {
           "version": "4.17.4",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
         },
         "regenerator-runtime": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+          "dev": true
         }
       }
     },
@@ -1523,6 +2630,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+      "dev": true,
       "requires": {
         "babel-helper-replace-supers": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
         "babel-runtime": "6.26.0"
@@ -1532,6 +2640,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
           "requires": {
             "core-js": "2.5.1",
             "regenerator-runtime": "0.11.0"
@@ -1540,12 +2649,14 @@
         "core-js": {
           "version": "2.5.1",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+          "dev": true
         },
         "regenerator-runtime": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+          "dev": true
         }
       }
     },
@@ -1580,6 +2691,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+      "dev": true,
       "requires": {
         "babel-helper-regex": "6.26.0",
         "babel-runtime": "6.26.0",
@@ -1590,6 +2702,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
           "requires": {
             "core-js": "2.5.1",
             "regenerator-runtime": "0.11.0"
@@ -1599,6 +2712,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
           "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+          "dev": true,
           "requires": {
             "babel-runtime": "6.26.0",
             "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
@@ -1609,17 +2723,20 @@
         "core-js": {
           "version": "2.5.1",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+          "dev": true
         },
         "lodash": {
           "version": "4.17.4",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
         },
         "regenerator-runtime": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+          "dev": true
         }
       }
     },
@@ -1634,6 +2751,7 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       },
@@ -1642,6 +2760,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
           "requires": {
             "core-js": "2.5.1",
             "regenerator-runtime": "0.11.0"
@@ -1650,12 +2769,14 @@
         "core-js": {
           "version": "2.5.1",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+          "dev": true
         },
         "regenerator-runtime": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+          "dev": true
         }
       }
     },
@@ -1663,6 +2784,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+      "dev": true,
       "requires": {
         "babel-helper-regex": "6.26.0",
         "babel-runtime": "6.26.0",
@@ -1673,6 +2795,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
           "requires": {
             "core-js": "2.5.1",
             "regenerator-runtime": "0.11.0"
@@ -1681,12 +2804,14 @@
         "core-js": {
           "version": "2.5.1",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+          "dev": true
         },
         "regenerator-runtime": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+          "dev": true
         }
       }
     },
@@ -1694,6 +2819,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+      "dev": true,
       "requires": {
         "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
         "babel-plugin-syntax-exponentiation-operator": "6.13.0",
@@ -1704,6 +2830,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
           "requires": {
             "core-js": "2.5.1",
             "regenerator-runtime": "0.11.0"
@@ -1712,12 +2839,14 @@
         "core-js": {
           "version": "2.5.1",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+          "dev": true
         },
         "regenerator-runtime": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+          "dev": true
         }
       }
     },
@@ -1725,6 +2854,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
+      "dev": true,
       "requires": {
         "regenerator-transform": "0.10.1"
       }
@@ -1741,6 +2871,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "core-js": "2.5.1",
@@ -1751,6 +2882,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
           "requires": {
             "core-js": "2.5.1",
             "regenerator-runtime": "0.11.0"
@@ -1759,19 +2891,22 @@
             "regenerator-runtime": {
               "version": "0.11.0",
               "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-              "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+              "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+              "dev": true
             }
           }
         },
         "core-js": {
           "version": "2.5.1",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+          "dev": true
         },
         "regenerator-runtime": {
           "version": "0.10.5",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+          "dev": true
         }
       }
     },
@@ -1779,6 +2914,7 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
       "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
+      "dev": true,
       "requires": {
         "babel-plugin-check-es2015-constants": "6.22.0",
         "babel-plugin-syntax-trailing-function-commas": "6.22.0",
@@ -1816,6 +2952,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
           "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+          "dev": true,
           "requires": {
             "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
             "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
@@ -1826,6 +2963,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
           "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+          "dev": true,
           "requires": {
             "babel-runtime": "6.26.0",
             "babel-template": "6.26.0",
@@ -1838,6 +2976,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
           "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
+          "dev": true,
           "requires": {
             "babel-plugin-transform-strict-mode": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
             "babel-runtime": "6.26.0",
@@ -1849,6 +2988,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
           "requires": {
             "core-js": "2.5.1",
             "regenerator-runtime": "0.11.0"
@@ -1858,6 +2998,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
           "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+          "dev": true,
           "requires": {
             "babel-runtime": "6.26.0",
             "babel-traverse": "6.26.0",
@@ -1870,6 +3011,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
           "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+          "dev": true,
           "requires": {
             "babel-code-frame": "6.26.0",
             "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
@@ -1886,6 +3028,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
           "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+          "dev": true,
           "requires": {
             "babel-runtime": "6.26.0",
             "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
@@ -1896,17 +3039,20 @@
         "babylon": {
           "version": "6.18.0",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+          "dev": true
         },
         "core-js": {
           "version": "2.5.1",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+          "dev": true
         },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
           "requires": {
             "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
           }
@@ -1914,27 +3060,86 @@
         "globals": {
           "version": "9.18.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+          "dev": true
         },
         "js-tokens": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+          "dev": true
         },
         "lodash": {
           "version": "4.17.4",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
         },
         "regenerator-runtime": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+          "dev": true
         },
         "semver": {
           "version": "5.4.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+          "dev": true
+        }
+      }
+    },
+    "babel-register": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+      "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+      "dev": true,
+      "requires": {
+        "babel-core": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.3",
+        "home-or-tmp": "2.0.0",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.4.18"
+      },
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
+          "requires": {
+            "core-js": "2.5.3",
+            "regenerator-runtime": "0.11.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+          "dev": true
         }
       }
     },
@@ -2003,6 +3208,12 @@
         "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.16.6.tgz",
         "to-fast-properties": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
       }
+    },
+    "babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "dev": true
     },
     "backbone": {
       "version": "1.3.3",
@@ -3024,6 +4235,7 @@
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/broccoli-debug/-/broccoli-debug-0.6.4.tgz",
       "integrity": "sha512-CixMUndBqTljCc26i6ubhBrGbAWXpWBsGJFce6ZOr76Tul2Ev1xxM0tmf7OjSzdYhkr5BrPd/CNbR9VMPi+NBg==",
+      "dev": true,
       "requires": {
         "broccoli-plugin": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.0.tgz",
         "fs-tree-diff": "0.5.7",
@@ -3037,6 +4249,7 @@
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.7.tgz",
           "integrity": "sha512-dJwDX6NBH7IfdfFjZAdHCZ6fIKc8LwR7kzqUhYRFJuX4g9ctG/7cuqJuwegGQsyLEykp6Z4krq+yIFMQlt7d9Q==",
+          "dev": true,
           "requires": {
             "heimdalljs-logger": "https://registry.npmjs.org/heimdalljs-logger/-/heimdalljs-logger-0.1.9.tgz",
             "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -3048,6 +4261,7 @@
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.2.5.tgz",
           "integrity": "sha1-aqVDCO7nk7ZCz/nPlHgURfN3MKw=",
+          "dev": true,
           "requires": {
             "rsvp": "3.2.1"
           }
@@ -3055,7 +4269,8 @@
         "rsvp": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
-          "integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo="
+          "integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo=",
+          "dev": true
         }
       }
     },
@@ -3837,6 +5052,280 @@
         "mime": "1.6.0"
       }
     },
+    "broccoli-persistent-filter": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
+      "integrity": "sha512-JwNLDvvXJlhUmr+CHcbVhCyp33NbCIAITjQZmJY9e8QzANXh3jpFWlhSFvkWghwKA8rTAKcXkW12agtiZjxr4g==",
+      "dev": true,
+      "requires": {
+        "async-disk-cache": "1.3.3",
+        "async-promise-queue": "1.0.4",
+        "broccoli-plugin": "1.3.0",
+        "fs-tree-diff": "0.5.7",
+        "hash-for-dep": "1.2.3",
+        "heimdalljs": "0.2.5",
+        "heimdalljs-logger": "0.1.9",
+        "mkdirp": "0.5.1",
+        "promise-map-series": "0.2.3",
+        "rimraf": "2.6.2",
+        "rsvp": "3.6.2",
+        "symlink-or-copy": "1.1.8",
+        "walk-sync": "0.3.2"
+      },
+      "dependencies": {
+        "balanced-match": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+          "dev": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "broccoli-plugin": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.0.tgz",
+          "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4=",
+          "dev": true,
+          "requires": {
+            "promise-map-series": "0.2.3",
+            "quick-temp": "0.1.8",
+            "rimraf": "2.6.2",
+            "symlink-or-copy": "1.1.8"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ensure-posix-path": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/ensure-posix-path/-/ensure-posix-path-1.0.2.tgz",
+          "integrity": "sha1-pls+QtC3HPxYXrd0+ZQ8jZuRsMI=",
+          "dev": true
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "heimdalljs": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.2.5.tgz",
+          "integrity": "sha1-aqVDCO7nk7ZCz/nPlHgURfN3MKw=",
+          "dev": true,
+          "requires": {
+            "rsvp": "3.2.1"
+          },
+          "dependencies": {
+            "rsvp": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
+              "integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo=",
+              "dev": true
+            }
+          }
+        },
+        "heimdalljs-logger": {
+          "version": "0.1.9",
+          "resolved": "https://registry.npmjs.org/heimdalljs-logger/-/heimdalljs-logger-0.1.9.tgz",
+          "integrity": "sha1-12raTkW3u294b8nAEKaOsuL68XY=",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "heimdalljs": "0.2.5"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        },
+        "matcher-collection": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.5.tgz",
+          "integrity": "sha512-nUCmzKipcJEwYsBVAFh5P+d7JBuhJaW1xs85Hara9xuMLqtCVUrW6DSC0JVIkluxEH2W45nPBM/wjHtBXa/tYA==",
+          "dev": true,
+          "requires": {
+            "minimatch": "3.0.4"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "mktemp": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.4.0.tgz",
+          "integrity": "sha1-bQUVYRyKjITkhKogABKbmOmB/ws=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "dev": true
+        },
+        "promise-map-series": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.3.tgz",
+          "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
+          "dev": true,
+          "requires": {
+            "rsvp": "3.6.2"
+          }
+        },
+        "quick-temp": {
+          "version": "0.1.8",
+          "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.8.tgz",
+          "integrity": "sha1-urAqJCq4+w3XWKPJd2sy+aXZRAg=",
+          "dev": true,
+          "requires": {
+            "mktemp": "0.4.0",
+            "rimraf": "2.6.2",
+            "underscore.string": "3.3.4"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "rsvp": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+          "dev": true
+        },
+        "sprintf-js": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
+          "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw=",
+          "dev": true
+        },
+        "symlink-or-copy": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.1.8.tgz",
+          "integrity": "sha1-yr5h4AEMHAI8Fzsl7lEIs39LSqM=",
+          "dev": true
+        },
+        "underscore.string": {
+          "version": "3.3.4",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
+          "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "1.1.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+          "dev": true
+        },
+        "walk-sync": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.2.tgz",
+          "integrity": "sha512-FMB5VqpLqOCcqrzA9okZFc0wq0Qbmdm396qJxvQZhDpyu0W95G9JCmp74tx7iyYnyOcBtUuKJsgIKAqjozvmmQ==",
+          "dev": true,
+          "requires": {
+            "ensure-posix-path": "1.0.2",
+            "matcher-collection": "1.0.5"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "dev": true
+        }
+      }
+    },
     "broccoli-plugin": {
       "version": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.0.tgz",
       "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4=",
@@ -3901,7 +5390,8 @@
     "broccoli-source": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-1.1.0.tgz",
-      "integrity": "sha1-VPDoLItz9GWAy7xPV48LMvyo+Ak="
+      "integrity": "sha1-VPDoLItz9GWAy7xPV48LMvyo+Ak=",
+      "dev": true
     },
     "broccoli-stew": {
       "version": "1.5.0",
@@ -4069,6 +5559,7 @@
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.9.1.tgz",
       "integrity": "sha512-3n3nPdbUqn3nWmsy4PeSQthz2ja1ndpoXta+dwFFNhveGjMg6FXpWYe12vsTpNoXJbzx3j7GZXdtoVIdvh3JbA==",
+      "dev": true,
       "requires": {
         "caniuse-lite": "1.0.30000775",
         "electron-to-chromium": "1.3.27"
@@ -4152,7 +5643,8 @@
     "caniuse-lite": {
       "version": "1.0.30000775",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000775.tgz",
-      "integrity": "sha1-dNJ/7dxH88hM+8sTDDCSo168LeI="
+      "integrity": "sha1-dNJ/7dxH88hM+8sTDDCSo168LeI=",
+      "dev": true
     },
     "capture-exit": {
       "version": "1.2.0",
@@ -4596,6 +6088,12 @@
       "integrity": "sha1-vXJ6f67XfnH/OYWskzUakSczrQ8=",
       "dev": true
     },
+    "convert-source-map": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+      "dev": true
+    },
     "cookie": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
@@ -4611,6 +6109,12 @@
     "copy-dereference": {
       "version": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz",
       "integrity": "sha1-axMYZUIP2BtBO6mUtE02VTERUrY=",
+      "dev": true
+    },
+    "core-js": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
       "dev": true
     },
     "core-object": {
@@ -4776,6 +6280,41 @@
         "fs-exists-sync": "0.1.0"
       }
     },
+    "detect-indent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+      "dev": true,
+      "requires": {
+        "repeating": "2.0.1"
+      },
+      "dependencies": {
+        "is-finite": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+          "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "dev": true
+        },
+        "repeating": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+          "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+          "dev": true,
+          "requires": {
+            "is-finite": "1.0.2"
+          }
+        }
+      }
+    },
     "diff": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
@@ -4821,7 +6360,8 @@
     "electron-to-chromium": {
       "version": "1.3.27",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.27.tgz",
-      "integrity": "sha1-eOy4o5kGYYe7N07t412ccFZagD0="
+      "integrity": "sha1-eOy4o5kGYYe7N07t412ccFZagD0=",
+      "dev": true
     },
     "ember-cli": {
       "version": "2.17.0",
@@ -5459,6 +6999,7 @@
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.10.0.tgz",
       "integrity": "sha512-MbgXmePweFzjkpN0l2eYFIU6XKfEKCaAx4Xk9wdL3vsPAvAm4N0DXnz4pOQ3OLezhl0bJJvutD3uLQ7Eo3sSTA==",
+      "dev": true,
       "requires": {
         "amd-name-resolver": "0.0.7",
         "babel-plugin-debug-macros": "0.1.11",
@@ -5479,6 +7020,7 @@
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.3.3.tgz",
           "integrity": "sha512-GyaWSbDAZCltxSobtj1m1ptXa0+zSdjWs3sM4IqnvhoRwMDHW5786sXQ1RiXbR3ZGuQe6NXMB4N0vUmW163cew==",
+          "dev": true,
           "requires": {
             "debug": "2.6.9",
             "heimdalljs": "0.2.5",
@@ -5493,6 +7035,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
           "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+          "dev": true,
           "requires": {
             "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
             "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
@@ -5503,6 +7046,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
           "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+          "dev": true,
           "requires": {
             "babel-code-frame": "6.26.0",
             "babel-generator": "6.26.0",
@@ -5529,6 +7073,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
           "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
+          "dev": true,
           "requires": {
             "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
             "babel-runtime": "6.26.0",
@@ -5544,6 +7089,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
           "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+          "dev": true,
           "requires": {
             "babel-core": "6.26.0",
             "babel-runtime": "6.26.0",
@@ -5558,6 +7104,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
           "requires": {
             "core-js": "2.5.1",
             "regenerator-runtime": "0.11.0"
@@ -5567,6 +7114,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
           "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+          "dev": true,
           "requires": {
             "babel-runtime": "6.26.0",
             "babel-traverse": "6.26.0",
@@ -5579,6 +7127,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
           "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+          "dev": true,
           "requires": {
             "babel-code-frame": "6.26.0",
             "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
@@ -5595,6 +7144,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
           "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+          "dev": true,
           "requires": {
             "babel-runtime": "6.26.0",
             "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
@@ -5605,12 +7155,14 @@
         "babylon": {
           "version": "6.18.0",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+          "dev": true
         },
         "broccoli-babel-transpiler": {
           "version": "6.1.2",
           "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.1.2.tgz",
           "integrity": "sha512-o1OUe5RZ5EP5+QICEmRNvWlhMvIciMisVACHu6qUPt6dE0Q0UnI5lUpWTmuXg/X+QuznqD/s1PApIpahv/QMZw==",
+          "dev": true,
           "requires": {
             "babel-core": "6.26.0",
             "broccoli-funnel": "1.2.0",
@@ -5628,6 +7180,7 @@
           "version": "1.4.3",
           "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
           "integrity": "sha512-JwNLDvvXJlhUmr+CHcbVhCyp33NbCIAITjQZmJY9e8QzANXh3jpFWlhSFvkWghwKA8rTAKcXkW12agtiZjxr4g==",
+          "dev": true,
           "requires": {
             "async-disk-cache": "1.3.3",
             "async-promise-queue": "1.0.4",
@@ -5647,22 +7200,26 @@
         "clone": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-          "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
+          "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
+          "dev": true
         },
         "convert-source-map": {
           "version": "1.5.1",
           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-          "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+          "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+          "dev": true
         },
         "core-js": {
           "version": "2.5.1",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+          "dev": true
         },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
           "requires": {
             "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
           }
@@ -5671,6 +7228,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
           "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+          "dev": true,
           "requires": {
             "repeating": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
           }
@@ -5679,6 +7237,7 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz",
           "integrity": "sha512-ssiNyVTp+PphroFum8guHX9py4xU1PCxkRYgb25NxumgjpKTPjhkgTfpRRKXlIQe+/wVMmhf+Uv6w9vSLZKWKQ==",
+          "dev": true,
           "requires": {
             "resolve": "1.5.0",
             "semver": "5.4.1"
@@ -5688,6 +7247,7 @@
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.7.tgz",
           "integrity": "sha512-dJwDX6NBH7IfdfFjZAdHCZ6fIKc8LwR7kzqUhYRFJuX4g9ctG/7cuqJuwegGQsyLEykp6Z4krq+yIFMQlt7d9Q==",
+          "dev": true,
           "requires": {
             "heimdalljs-logger": "https://registry.npmjs.org/heimdalljs-logger/-/heimdalljs-logger-0.1.9.tgz",
             "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -5698,12 +7258,14 @@
         "globals": {
           "version": "9.18.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+          "dev": true
         },
         "hash-for-dep": {
           "version": "1.2.3",
           "resolved": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
           "integrity": "sha512-NE//rDaCFpWHViw30YM78OAGBShU+g4dnUGY3UWGyEzPOGYg/ptOjk32nEc+bC1xz+RfK5UIs6lOL6eQdrV4Ow==",
+          "dev": true,
           "requires": {
             "broccoli-kitchen-sink-helpers": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.3.1.tgz",
             "heimdalljs": "0.2.5",
@@ -5715,6 +7277,7 @@
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.2.5.tgz",
           "integrity": "sha1-aqVDCO7nk7ZCz/nPlHgURfN3MKw=",
+          "dev": true,
           "requires": {
             "rsvp": "3.2.1"
           },
@@ -5722,7 +7285,8 @@
             "rsvp": {
               "version": "3.2.1",
               "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
-              "integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo="
+              "integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo=",
+              "dev": true
             }
           }
         },
@@ -5730,6 +7294,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
           "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+          "dev": true,
           "requires": {
             "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
             "os-tmpdir": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
@@ -5738,37 +7303,44 @@
         "js-tokens": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+          "dev": true
         },
         "jsesc": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+          "dev": true
         },
         "json5": {
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+          "dev": true
         },
         "lodash": {
           "version": "4.17.4",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
         },
         "private": {
           "version": "0.1.8",
           "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-          "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+          "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+          "dev": true
         },
         "regenerator-runtime": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+          "dev": true
         },
         "resolve": {
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
           "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+          "dev": true,
           "requires": {
             "path-parse": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz"
           }
@@ -5777,6 +7349,7 @@
           "version": "2.6.2",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+          "dev": true,
           "requires": {
             "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
           }
@@ -5784,22 +7357,26 @@
         "rsvp": {
           "version": "3.6.2",
           "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
+          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+          "dev": true
         },
         "semver": {
           "version": "5.4.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+          "dev": true
         },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
         },
         "source-map-support": {
           "version": "0.4.18",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
           "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+          "dev": true,
           "requires": {
             "source-map": "0.5.7"
           }
@@ -5925,9 +7502,9 @@
       }
     },
     "ember-cli-foundation-6-sass": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/ember-cli-foundation-6-sass/-/ember-cli-foundation-6-sass-0.0.17.tgz",
-      "integrity": "sha1-iodtfDqDzIMRSOHWwTbOmBheQCc=",
+      "version": "0.0.24",
+      "resolved": "https://registry.npmjs.org/ember-cli-foundation-6-sass/-/ember-cli-foundation-6-sass-0.0.24.tgz",
+      "integrity": "sha1-SRvaSQ6Mcjv7RDofP1duP01ImpY=",
       "dev": true,
       "requires": {
         "babel-core": "6.26.0",
@@ -5942,60 +7519,16 @@
         "babel-plugin-transform-es2015-spread": "6.22.0",
         "babel-plugin-transform-es2015-template-literals": "6.22.0",
         "babel-register": "6.26.0",
+        "broccoli-funnel": "1.2.0",
+        "broccoli-merge-trees": "2.0.0",
+        "ember-cli-babel": "6.10.0",
         "ember-cli-htmlbars": "1.3.4",
-        "ember-cli-sass": "5.6.0"
+        "ember-cli-htmlbars-inline-precompile": "0.4.4",
+        "ember-cli-sass": "6.2.0",
+        "ember-cli-version-checker": "1.3.1",
+        "foundation-sites": "6.4.3"
       },
       "dependencies": {
-        "abbrev": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-          "dev": true
-        },
-        "acorn": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
-          "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
-          "dev": true
-        },
-        "ajv": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.0.tgz",
-          "integrity": "sha1-6yhAdG6dxIvV4GOjbj/UAMXqtak=",
-          "dev": true,
-          "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.0.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
-          }
-        },
-        "align-text": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-          "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2",
-            "longest": "1.0.1",
-            "repeat-string": "1.6.1"
-          }
-        },
-        "alter": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
-          "integrity": "sha1-x1iICGF1cgNKrmJICvJrHU0cs80=",
-          "dev": true,
-          "requires": {
-            "stable": "0.1.6"
-          }
-        },
-        "amdefine": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-          "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-          "dev": true
-        },
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -6008,91 +7541,6 @@
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
-        "aproba": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-          "dev": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-          "dev": true,
-          "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.3"
-          }
-        },
-        "array-find-index": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-          "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
-          "dev": true
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-          "dev": true
-        },
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        },
-        "ast-traverse": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz",
-          "integrity": "sha1-ac8rg4bxnc2hux4F1o/jWdiJfeY=",
-          "dev": true
-        },
-        "ast-types": {
-          "version": "0.9.6",
-          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
-          "integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk=",
-          "dev": true
-        },
-        "async-disk-cache": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.3.3.tgz",
-          "integrity": "sha512-GyaWSbDAZCltxSobtj1m1ptXa0+zSdjWs3sM4IqnvhoRwMDHW5786sXQ1RiXbR3ZGuQe6NXMB4N0vUmW163cew==",
-          "dev": true,
-          "requires": {
-            "debug": "2.6.9",
-            "heimdalljs": "0.2.5",
-            "istextorbinary": "2.1.0",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.2",
-            "rsvp": "3.6.2",
-            "username-sync": "1.0.1"
-          }
-        },
-        "async-foreach": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
-          "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
-          "dev": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-          "dev": true
-        },
-        "aws-sign2": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-          "dev": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
-          "dev": true
-        },
         "babel-code-frame": {
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -6102,49 +7550,6 @@
             "chalk": "1.1.3",
             "esutils": "2.0.2",
             "js-tokens": "3.0.2"
-          }
-        },
-        "babel-core": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
-          "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
-          "dev": true,
-          "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-generator": "6.26.0",
-            "babel-helpers": "6.24.1",
-            "babel-messages": "6.23.0",
-            "babel-register": "6.26.0",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "convert-source-map": "1.5.1",
-            "debug": "2.6.9",
-            "json5": "0.5.1",
-            "lodash": "4.17.4",
-            "minimatch": "3.0.4",
-            "path-is-absolute": "1.0.1",
-            "private": "0.1.8",
-            "slash": "1.0.0",
-            "source-map": "0.5.7"
-          }
-        },
-        "babel-generator": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
-          "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
-          "dev": true,
-          "requires": {
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "detect-indent": "4.0.0",
-            "jsesc": "1.3.0",
-            "lodash": "4.17.4",
-            "source-map": "0.5.7",
-            "trim-right": "1.0.1"
           }
         },
         "babel-helper-call-delegate": {
@@ -6228,16 +7633,6 @@
             "babel-types": "6.26.0"
           }
         },
-        "babel-helpers": {
-          "version": "6.24.1",
-          "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
-          "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-          "dev": true,
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0"
-          }
-        },
         "babel-messages": {
           "version": "6.23.0",
           "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
@@ -6246,95 +7641,6 @@
           "requires": {
             "babel-runtime": "6.26.0"
           }
-        },
-        "babel-plugin-constant-folding": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz",
-          "integrity": "sha1-g2HTZMmORJw2kr26Ue/whEKQqo4=",
-          "dev": true
-        },
-        "babel-plugin-dead-code-elimination": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz",
-          "integrity": "sha1-X3xFEnTc18zNv7s+C4XdKBIfD2U=",
-          "dev": true
-        },
-        "babel-plugin-eval": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz",
-          "integrity": "sha1-ovrtJc5r5preS/7CY/cBaRlZUNo=",
-          "dev": true
-        },
-        "babel-plugin-inline-environment-variables": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz",
-          "integrity": "sha1-H1jOkSB61qgmqL9kX6/mj/X+P/4=",
-          "dev": true
-        },
-        "babel-plugin-jscript": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz",
-          "integrity": "sha1-jzQsOCduh6R9X6CovT1etsytj8w=",
-          "dev": true
-        },
-        "babel-plugin-member-expression-literals": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz",
-          "integrity": "sha1-zF7bD6qNyScXDnTW0cAkQAIWJNM=",
-          "dev": true
-        },
-        "babel-plugin-property-literals": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz",
-          "integrity": "sha1-AlIwGQAZKYCxwRjv6kjOk6q4MzY=",
-          "dev": true
-        },
-        "babel-plugin-proto-to-assign": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz",
-          "integrity": "sha1-xJ56/QL1d7xNoF6i3wAiUM980SM=",
-          "dev": true,
-          "requires": {
-            "lodash": "3.10.1"
-          },
-          "dependencies": {
-            "lodash": {
-              "version": "3.10.1",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-              "dev": true
-            }
-          }
-        },
-        "babel-plugin-react-constant-elements": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz",
-          "integrity": "sha1-lGc26DeEKcvDSdz/YvUcFDs041o=",
-          "dev": true
-        },
-        "babel-plugin-react-display-name": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz",
-          "integrity": "sha1-dU/jiSboQkpOexWrbqYTne4FFPw=",
-          "dev": true
-        },
-        "babel-plugin-remove-console": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz",
-          "integrity": "sha1-2PJFVsOgUAXUKqqv0neH9T/wE6c=",
-          "dev": true
-        },
-        "babel-plugin-remove-debugger": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz",
-          "integrity": "sha1-/S6jzWGkKK0fO5yJiC/0KT6MFMc=",
-          "dev": true
-        },
-        "babel-plugin-runtime": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz",
-          "integrity": "sha1-v3x9lm3Vbs1cF/ocslPJrLflSq8=",
-          "dev": true
         },
         "babel-plugin-transform-es2015-arrow-functions": {
           "version": "6.22.0",
@@ -6352,19 +7658,6 @@
           "dev": true,
           "requires": {
             "babel-runtime": "6.26.0"
-          }
-        },
-        "babel-plugin-transform-es2015-block-scoping": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
-          "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
-          "dev": true,
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "lodash": "4.17.4"
           }
         },
         "babel-plugin-transform-es2015-classes": {
@@ -6391,18 +7684,6 @@
           "dev": true,
           "requires": {
             "babel-runtime": "6.26.0"
-          }
-        },
-        "babel-plugin-transform-es2015-modules-commonjs": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
-          "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
-          "dev": true,
-          "requires": {
-            "babel-plugin-transform-strict-mode": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-types": "6.26.0"
           }
         },
         "babel-plugin-transform-es2015-parameters": {
@@ -6447,54 +7728,14 @@
             "babel-runtime": "6.26.0"
           }
         },
-        "babel-plugin-transform-strict-mode": {
-          "version": "6.24.1",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
-          "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-          "dev": true,
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
-          }
-        },
-        "babel-plugin-undeclared-variables-check": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
-          "integrity": "sha1-XPGqU52BP/ZOmWQSkK9iCWX2Xe4=",
-          "dev": true,
-          "requires": {
-            "leven": "1.0.2"
-          }
-        },
-        "babel-plugin-undefined-to-void": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz",
-          "integrity": "sha1-f1eO+LeN+uYAM4XYQXph7aBuL4E=",
-          "dev": true
-        },
-        "babel-register": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
-          "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-          "dev": true,
-          "requires": {
-            "babel-core": "6.26.0",
-            "babel-runtime": "6.26.0",
-            "core-js": "2.5.1",
-            "home-or-tmp": "2.0.0",
-            "lodash": "4.17.4",
-            "mkdirp": "0.5.1",
-            "source-map-support": "0.4.18"
-          }
-        },
         "babel-runtime": {
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "2.5.1",
-            "regenerator-runtime": "0.11.0"
+            "core-js": "2.5.3",
+            "regenerator-runtime": "0.11.1"
           }
         },
         "babel-template": {
@@ -6539,48 +7780,11 @@
             "to-fast-properties": "1.0.3"
           }
         },
-        "babylon": {
-          "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-          "dev": true
-        },
         "balanced-match": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "binaryextensions": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.0.0.tgz",
-          "integrity": "sha1-5ZfRp6ajVYotHHJBoWyZll5qpA8=",
-          "dev": true
-        },
-        "bluebird": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
-          "dev": true
-        },
-        "boom": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-          "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-          "dev": true,
-          "requires": {
-            "hoek": "4.2.0"
-          }
         },
         "brace-expansion": {
           "version": "1.1.8",
@@ -6592,257 +7796,14 @@
             "concat-map": "0.0.1"
           }
         },
-        "breakable": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz",
-          "integrity": "sha1-eEp5eRWjjq0nutRWtVcstLuqeME=",
-          "dev": true
-        },
-        "broccoli-babel-transpiler": {
-          "version": "5.7.2",
-          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.2.tgz",
-          "integrity": "sha512-vFQ+aSR9J81fm3MXXQGgDxswYINHl2p5duLvRLVnpmgPDNdpdsa30gh3xnmhzR/GwWFBfUNle7aYxthlgvsN0w==",
+        "broccoli-merge-trees": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.0.tgz",
+          "integrity": "sha1-EK6kbdXOvMi499WlTwqEpPC7kLk=",
           "dev": true,
           "requires": {
-            "babel-core": "5.8.38",
-            "broccoli-funnel": "1.2.0",
-            "broccoli-merge-trees": "1.2.4",
-            "broccoli-persistent-filter": "1.4.3",
-            "clone": "0.2.0",
-            "hash-for-dep": "1.2.3",
-            "heimdalljs-logger": "0.1.9",
-            "json-stable-stringify": "1.0.1",
-            "rsvp": "3.6.2",
-            "workerpool": "2.3.0"
-          },
-          "dependencies": {
-            "babel-core": {
-              "version": "5.8.38",
-              "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
-              "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
-              "dev": true,
-              "requires": {
-                "babel-plugin-constant-folding": "1.0.1",
-                "babel-plugin-dead-code-elimination": "1.0.2",
-                "babel-plugin-eval": "1.0.1",
-                "babel-plugin-inline-environment-variables": "1.0.1",
-                "babel-plugin-jscript": "1.0.4",
-                "babel-plugin-member-expression-literals": "1.0.1",
-                "babel-plugin-property-literals": "1.0.1",
-                "babel-plugin-proto-to-assign": "1.0.4",
-                "babel-plugin-react-constant-elements": "1.0.3",
-                "babel-plugin-react-display-name": "1.0.3",
-                "babel-plugin-remove-console": "1.0.1",
-                "babel-plugin-remove-debugger": "1.0.1",
-                "babel-plugin-runtime": "1.0.7",
-                "babel-plugin-undeclared-variables-check": "1.0.2",
-                "babel-plugin-undefined-to-void": "1.1.6",
-                "babylon": "5.8.38",
-                "bluebird": "2.11.0",
-                "chalk": "1.1.3",
-                "convert-source-map": "1.5.1",
-                "core-js": "1.2.7",
-                "debug": "2.6.9",
-                "detect-indent": "3.0.1",
-                "esutils": "2.0.2",
-                "fs-readdir-recursive": "0.1.2",
-                "globals": "6.4.1",
-                "home-or-tmp": "1.0.0",
-                "is-integer": "1.0.7",
-                "js-tokens": "1.0.1",
-                "json5": "0.4.0",
-                "lodash": "3.10.1",
-                "minimatch": "2.0.10",
-                "output-file-sync": "1.1.2",
-                "path-exists": "1.0.0",
-                "path-is-absolute": "1.0.1",
-                "private": "0.1.8",
-                "regenerator": "0.8.40",
-                "regexpu": "1.3.0",
-                "repeating": "1.1.3",
-                "resolve": "1.5.0",
-                "shebang-regex": "1.0.0",
-                "slash": "1.0.0",
-                "source-map": "0.5.7",
-                "source-map-support": "0.2.10",
-                "to-fast-properties": "1.0.3",
-                "trim-right": "1.0.1",
-                "try-resolve": "1.0.1"
-              }
-            },
-            "babylon": {
-              "version": "5.8.38",
-              "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
-              "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0=",
-              "dev": true
-            },
-            "clone": {
-              "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-              "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
-              "dev": true
-            },
-            "core-js": {
-              "version": "1.2.7",
-              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-              "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
-              "dev": true
-            },
-            "detect-indent": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-              "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
-              "dev": true,
-              "requires": {
-                "get-stdin": "4.0.1",
-                "minimist": "1.2.0",
-                "repeating": "1.1.3"
-              }
-            },
-            "globals": {
-              "version": "6.4.1",
-              "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
-              "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08=",
-              "dev": true
-            },
-            "home-or-tmp": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-              "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
-              "dev": true,
-              "requires": {
-                "os-tmpdir": "1.0.2",
-                "user-home": "1.1.1"
-              }
-            },
-            "js-tokens": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz",
-              "integrity": "sha1-zENaXIuUrRWst5gxQPyAGCyJrq4=",
-              "dev": true
-            },
-            "json5": {
-              "version": "0.4.0",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-              "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0=",
-              "dev": true
-            },
-            "lodash": {
-              "version": "3.10.1",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-              "dev": true
-            },
-            "minimatch": {
-              "version": "2.0.10",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-              "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-              "dev": true,
-              "requires": {
-                "brace-expansion": "1.1.8"
-              }
-            },
-            "minimist": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-              "dev": true
-            },
-            "path-exists": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-              "integrity": "sha1-1aiZjrce83p0w06w2eum6HjuoIE=",
-              "dev": true
-            },
-            "repeating": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-              "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
-              "dev": true,
-              "requires": {
-                "is-finite": "1.0.2"
-              }
-            },
-            "source-map-support": {
-              "version": "0.2.10",
-              "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
-              "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
-              "dev": true,
-              "requires": {
-                "source-map": "0.1.32"
-              },
-              "dependencies": {
-                "source-map": {
-                  "version": "0.1.32",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-                  "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
-                  "dev": true,
-                  "requires": {
-                    "amdefine": "1.0.1"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "broccoli-caching-writer": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/broccoli-caching-writer/-/broccoli-caching-writer-3.0.3.tgz",
-          "integrity": "sha1-C9LJapc41qarWQ8HujXFFX19tHY=",
-          "dev": true,
-          "requires": {
-            "broccoli-kitchen-sink-helpers": "0.3.1",
             "broccoli-plugin": "1.3.0",
-            "debug": "2.6.9",
-            "rimraf": "2.6.2",
-            "rsvp": "3.6.2",
-            "walk-sync": "0.3.2"
-          }
-        },
-        "broccoli-kitchen-sink-helpers": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.3.1.tgz",
-          "integrity": "sha1-d8fBgZS5ZkFj7E/O4nk0RJJuDAY=",
-          "dev": true,
-          "requires": {
-            "glob": "5.0.15",
-            "mkdirp": "0.5.1"
-          },
-          "dependencies": {
-            "glob": {
-              "version": "5.0.15",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-              "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-              "dev": true,
-              "requires": {
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
-              }
-            }
-          }
-        },
-        "broccoli-persistent-filter": {
-          "version": "1.4.3",
-          "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
-          "integrity": "sha512-JwNLDvvXJlhUmr+CHcbVhCyp33NbCIAITjQZmJY9e8QzANXh3jpFWlhSFvkWghwKA8rTAKcXkW12agtiZjxr4g==",
-          "dev": true,
-          "requires": {
-            "async-disk-cache": "1.3.3",
-            "async-promise-queue": "1.0.4",
-            "broccoli-plugin": "1.3.0",
-            "fs-tree-diff": "0.5.7",
-            "hash-for-dep": "1.2.3",
-            "heimdalljs": "0.2.5",
-            "heimdalljs-logger": "0.1.9",
-            "mkdirp": "0.5.1",
-            "promise-map-series": "0.2.3",
-            "rimraf": "2.6.2",
-            "rsvp": "3.6.2",
-            "symlink-or-copy": "1.1.8",
-            "walk-sync": "0.3.2"
+            "merge-trees": "1.0.1"
           }
         },
         "broccoli-plugin": {
@@ -6855,72 +7816,6 @@
             "quick-temp": "0.1.8",
             "rimraf": "2.6.2",
             "symlink-or-copy": "1.1.8"
-          }
-        },
-        "broccoli-sass-source-maps": {
-          "version": "1.8.1",
-          "resolved": "https://registry.npmjs.org/broccoli-sass-source-maps/-/broccoli-sass-source-maps-1.8.1.tgz",
-          "integrity": "sha1-EV4yviXcXxaGrxyNH6TExidJ8LY=",
-          "dev": true,
-          "requires": {
-            "broccoli-caching-writer": "3.0.3",
-            "include-path-searcher": "0.1.0",
-            "mkdirp": "0.3.5",
-            "node-sass": "3.13.1",
-            "object-assign": "2.1.1",
-            "rsvp": "3.6.2"
-          },
-          "dependencies": {
-            "mkdirp": {
-              "version": "0.3.5",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-              "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
-              "dev": true
-            },
-            "object-assign": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-              "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
-              "dev": true
-            }
-          }
-        },
-        "builtin-modules": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-          "dev": true
-        },
-        "camelcase": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-          "dev": true
-        },
-        "camelcase-keys": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-          "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-          "dev": true,
-          "requires": {
-            "camelcase": "2.1.1",
-            "map-obj": "1.0.1"
-          }
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-          "dev": true
-        },
-        "center-align": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-          "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-          "dev": true,
-          "requires": {
-            "align-text": "0.1.4",
-            "lazy-cache": "1.0.4"
           }
         },
         "chalk": {
@@ -6936,171 +7831,11 @@
             "supports-color": "2.0.0"
           }
         },
-        "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true,
-          "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
-          }
-        },
-        "clone": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
-          "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
-          "dev": true
-        },
-        "co": {
-          "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-          "dev": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-          "dev": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "commander": {
-          "version": "2.12.2",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
-          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
-          "dev": true
-        },
-        "commoner": {
-          "version": "0.10.8",
-          "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
-          "integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
-          "dev": true,
-          "requires": {
-            "commander": "2.12.2",
-            "detective": "4.6.0",
-            "glob": "5.0.15",
-            "graceful-fs": "4.1.11",
-            "iconv-lite": "0.4.19",
-            "mkdirp": "0.5.1",
-            "private": "0.1.8",
-            "q": "1.5.1",
-            "recast": "0.11.23"
-          },
-          "dependencies": {
-            "glob": {
-              "version": "5.0.15",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-              "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-              "dev": true,
-              "requires": {
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
-              }
-            },
-            "recast": {
-              "version": "0.11.23",
-              "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
-              "integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
-              "dev": true,
-              "requires": {
-                "ast-types": "0.9.6",
-                "esprima": "3.1.3",
-                "private": "0.1.8",
-                "source-map": "0.5.7"
-              }
-            }
-          }
-        },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
-        },
-        "convert-source-map": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-          "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
-          "dev": true
-        },
-        "core-js": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
-          "dev": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-          "dev": true
-        },
-        "cross-spawn": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
-          "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "4.1.1",
-            "which": "1.3.0"
-          }
-        },
-        "cryptiles": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-          "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-          "dev": true,
-          "requires": {
-            "boom": "5.2.0"
-          },
-          "dependencies": {
-            "boom": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-              "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-              "dev": true,
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            }
-          }
-        },
-        "currently-unhandled": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-          "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-          "dev": true,
-          "requires": {
-            "array-find-index": "1.0.2"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          }
         },
         "debug": {
           "version": "2.6.9",
@@ -7109,129 +7844,6 @@
           "dev": true,
           "requires": {
             "ms": "2.0.0"
-          }
-        },
-        "decamelize": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-          "dev": true
-        },
-        "defined": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-          "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
-          "dev": true
-        },
-        "defs": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
-          "integrity": "sha1-siYJ8sehG6ej2xFoBcE5scr/qdI=",
-          "dev": true,
-          "requires": {
-            "alter": "0.2.0",
-            "ast-traverse": "0.1.1",
-            "breakable": "1.0.0",
-            "esprima-fb": "15001.1001.0-dev-harmony-fb",
-            "simple-fmt": "0.1.0",
-            "simple-is": "0.2.0",
-            "stringmap": "0.2.2",
-            "stringset": "0.2.1",
-            "tryor": "0.1.2",
-            "yargs": "3.27.0"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "1.2.1",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-              "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-              "dev": true
-            },
-            "cliui": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-              "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-              "dev": true,
-              "requires": {
-                "center-align": "0.1.3",
-                "right-align": "0.1.3",
-                "wordwrap": "0.0.2"
-              }
-            },
-            "yargs": {
-              "version": "3.27.0",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
-              "integrity": "sha1-ISBUaTFuk5Ex1Z8toMbX+YIh6kA=",
-              "dev": true,
-              "requires": {
-                "camelcase": "1.2.1",
-                "cliui": "2.1.0",
-                "decamelize": "1.2.0",
-                "os-locale": "1.4.0",
-                "window-size": "0.1.4",
-                "y18n": "3.2.1"
-              }
-            }
-          }
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-          "dev": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-          "dev": true
-        },
-        "detect-indent": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-          "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-          "dev": true,
-          "requires": {
-            "repeating": "2.0.1"
-          }
-        },
-        "detective": {
-          "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/detective/-/detective-4.6.0.tgz",
-          "integrity": "sha512-bvuiWqtm2RYtEnfjAuRw9XTJhUbfbOfsmtIRXQcNgMyUplxJP611EzoVxObkSvaSnfBUEjoKVzaUzdtIRMcCXg==",
-          "dev": true,
-          "requires": {
-            "acorn": "5.2.1",
-            "defined": "1.0.0"
-          }
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "editions": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.3.tgz",
-          "integrity": "sha1-CQcQG92iD6w8vjNMJ8vQaI3Jmls=",
-          "dev": true
-        },
-        "ember-cli-babel": {
-          "version": "5.1.10",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.1.10.tgz",
-          "integrity": "sha1-1APxeKq2AuEzfEA8WljAIAqJaao=",
-          "dev": true,
-          "requires": {
-            "broccoli-babel-transpiler": "5.7.2",
-            "broccoli-funnel": "1.2.0",
-            "clone": "1.0.3",
-            "ember-cli-version-checker": "1.3.1",
-            "resolve": "1.5.0"
           }
         },
         "ember-cli-htmlbars": {
@@ -7247,33 +7859,37 @@
             "strip-bom": "2.0.0"
           }
         },
-        "ember-cli-sass": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-sass/-/ember-cli-sass-5.6.0.tgz",
-          "integrity": "sha1-eS3mdUS7kD7vQho+WcSEhA/qU1I=",
+        "ember-cli-htmlbars-inline-precompile": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/ember-cli-htmlbars-inline-precompile/-/ember-cli-htmlbars-inline-precompile-0.4.4.tgz",
+          "integrity": "sha1-JKdhcVJjDWSgR+VTty4AljpPjXM=",
           "dev": true,
           "requires": {
-            "broccoli-funnel": "1.2.0",
-            "broccoli-merge-trees": "1.2.4",
-            "broccoli-sass-source-maps": "1.8.1",
-            "ember-cli-babel": "5.1.10",
-            "ember-cli-version-checker": "1.3.1",
-            "merge": "1.2.0"
+            "babel-plugin-htmlbars-inline-precompile": "0.2.3",
+            "ember-cli-version-checker": "2.1.0",
+            "hash-for-dep": "1.2.3",
+            "silent-error": "1.1.0"
+          },
+          "dependencies": {
+            "ember-cli-version-checker": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz",
+              "integrity": "sha512-ssiNyVTp+PphroFum8guHX9py4xU1PCxkRYgb25NxumgjpKTPjhkgTfpRRKXlIQe+/wVMmhf+Uv6w9vSLZKWKQ==",
+              "dev": true,
+              "requires": {
+                "resolve": "1.5.0",
+                "semver": "5.4.1"
+              }
+            }
           }
         },
-        "ensure-posix-path": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/ensure-posix-path/-/ensure-posix-path-1.0.2.tgz",
-          "integrity": "sha1-pls+QtC3HPxYXrd0+ZQ8jZuRsMI=",
-          "dev": true
-        },
-        "error-ex": {
+        "ember-cli-version-checker": {
           "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-          "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
+          "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
           "dev": true,
           "requires": {
-            "is-arrayish": "0.2.1"
+            "semver": "5.4.1"
           }
         },
         "escape-string-regexp": {
@@ -7282,138 +7898,17 @@
           "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         },
-        "esprima-fb": {
-          "version": "15001.1001.0-dev-harmony-fb",
-          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
-          "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk=",
-          "dev": true
-        },
         "esutils": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
           "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
           "dev": true
         },
-        "extend": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-          "dev": true
-        },
-        "extsprintf": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-          "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-          "dev": true
-        },
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-          "dev": true
-        },
-        "form-data": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-          "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
-          "dev": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
-          }
-        },
-        "fs-readdir-recursive": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz",
-          "integrity": "sha1-MVtPuMHKW4xH3v7zGdBz2tNWgFk=",
-          "dev": true
-        },
-        "fs-tree-diff": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.7.tgz",
-          "integrity": "sha512-dJwDX6NBH7IfdfFjZAdHCZ6fIKc8LwR7kzqUhYRFJuX4g9ctG/7cuqJuwegGQsyLEykp6Z4krq+yIFMQlt7d9Q==",
-          "dev": true,
-          "requires": {
-            "heimdalljs-logger": "0.1.9",
-            "object-assign": "4.1.1",
-            "path-posix": "1.0.0",
-            "symlink-or-copy": "1.1.8"
-          }
-        },
         "fs.realpath": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true
-        },
-        "fstream": {
-          "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-          "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.2"
-          }
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-          "dev": true,
-          "requires": {
-            "aproba": "1.2.0",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
-          }
-        },
-        "gaze": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
-          "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
-          "dev": true,
-          "requires": {
-            "globule": "1.2.0"
-          }
-        },
-        "get-caller-file": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-          "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
-          "dev": true
-        },
-        "get-stdin": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-          "dev": true
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          }
         },
         "glob": {
           "version": "7.1.2",
@@ -7429,45 +7924,6 @@
             "path-is-absolute": "1.0.1"
           }
         },
-        "globals": {
-          "version": "9.18.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-          "dev": true
-        },
-        "globule": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.0.tgz",
-          "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
-          "dev": true,
-          "requires": {
-            "glob": "7.1.2",
-            "lodash": "4.17.4",
-            "minimatch": "3.0.4"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        },
-        "har-schema": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-          "dev": true
-        },
-        "har-validator": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-          "dev": true,
-          "requires": {
-            "ajv": "5.5.0",
-            "har-schema": "2.0.0"
-          }
-        },
         "has-ansi": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -7475,123 +7931,6 @@
           "dev": true,
           "requires": {
             "ansi-regex": "2.1.1"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-          "dev": true
-        },
-        "hash-for-dep": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
-          "integrity": "sha512-NE//rDaCFpWHViw30YM78OAGBShU+g4dnUGY3UWGyEzPOGYg/ptOjk32nEc+bC1xz+RfK5UIs6lOL6eQdrV4Ow==",
-          "dev": true,
-          "requires": {
-            "broccoli-kitchen-sink-helpers": "0.3.1",
-            "heimdalljs": "0.2.5",
-            "heimdalljs-logger": "0.1.9",
-            "resolve": "1.5.0"
-          }
-        },
-        "hawk": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-          "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-          "dev": true,
-          "requires": {
-            "boom": "4.3.1",
-            "cryptiles": "3.1.2",
-            "hoek": "4.2.0",
-            "sntp": "2.1.0"
-          }
-        },
-        "heimdalljs": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.2.5.tgz",
-          "integrity": "sha1-aqVDCO7nk7ZCz/nPlHgURfN3MKw=",
-          "dev": true,
-          "requires": {
-            "rsvp": "3.2.1"
-          },
-          "dependencies": {
-            "rsvp": {
-              "version": "3.2.1",
-              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
-              "integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo=",
-              "dev": true
-            }
-          }
-        },
-        "heimdalljs-logger": {
-          "version": "0.1.9",
-          "resolved": "https://registry.npmjs.org/heimdalljs-logger/-/heimdalljs-logger-0.1.9.tgz",
-          "integrity": "sha1-12raTkW3u294b8nAEKaOsuL68XY=",
-          "dev": true,
-          "requires": {
-            "debug": "2.6.9",
-            "heimdalljs": "0.2.5"
-          }
-        },
-        "hoek": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-          "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
-          "dev": true
-        },
-        "home-or-tmp": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-          "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-          "dev": true,
-          "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
-          }
-        },
-        "hosted-git-info": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-          "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
-          "dev": true
-        },
-        "http-signature": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
-          }
-        },
-        "iconv-lite": {
-          "version": "0.4.19",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-          "dev": true
-        },
-        "in-publish": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
-          "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
-          "dev": true
-        },
-        "include-path-searcher": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/include-path-searcher/-/include-path-searcher-0.1.0.tgz",
-          "integrity": "sha1-wM8t36Fk+y6uB7x8pDp/GRy0170=",
-          "dev": true
-        },
-        "indent-string": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-          "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-          "dev": true,
-          "requires": {
-            "repeating": "2.0.1"
           }
         },
         "inflight": {
@@ -7619,130 +7958,10 @@
             "loose-envify": "1.3.1"
           }
         },
-        "invert-kv": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-          "dev": true
-        },
-        "is-arrayish": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-          "dev": true
-        },
-        "is-buffer": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-          "dev": true
-        },
-        "is-builtin-module": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-          "dev": true,
-          "requires": {
-            "builtin-modules": "1.1.1"
-          }
-        },
-        "is-finite": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-          "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "is-integer": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.7.tgz",
-          "integrity": "sha1-a96Bqs3feLZZtmKdYpytxRqIbVw=",
-          "dev": true,
-          "requires": {
-            "is-finite": "1.0.2"
-          }
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-          "dev": true
-        },
         "is-utf8": {
           "version": "0.2.1",
           "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
           "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-          "dev": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "isexe": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-          "dev": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-          "dev": true
-        },
-        "istextorbinary": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.1.0.tgz",
-          "integrity": "sha1-2+0qb1G+L3R1to+JRlgRFBt1iHQ=",
-          "dev": true,
-          "requires": {
-            "binaryextensions": "2.0.0",
-            "editions": "1.3.3",
-            "textextensions": "2.1.0"
-          }
-        },
-        "js-base64": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.0.tgz",
-          "integrity": "sha512-Wehd+7Pf9tFvGb+ydPm9TjYjV8X1YHOVyG8QyELZxEMqOhemVwGRmoG8iQ/soqI3n8v4xn59zaLxiCJiaaRzKA==",
-          "dev": true
-        },
-        "js-tokens": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-          "dev": true
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-          "dev": true,
-          "optional": true
-        },
-        "jsesc": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-          "dev": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
           "dev": true
         },
         "json-stable-stringify": {
@@ -7754,101 +7973,16 @@
             "jsonify": "0.0.0"
           }
         },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-          "dev": true
-        },
-        "json5": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-          "dev": true
-        },
         "jsonify": {
           "version": "0.0.0",
           "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
           "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
           "dev": true
         },
-        "jsprim": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-          "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.3.0",
-            "json-schema": "0.2.3",
-            "verror": "1.10.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "1.1.6"
-          }
-        },
-        "lazy-cache": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-          "dev": true
-        },
-        "lcid": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-          "dev": true,
-          "requires": {
-            "invert-kv": "1.0.0"
-          }
-        },
-        "leven": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz",
-          "integrity": "sha1-kUS27ryl8dBoAWnxpncNzqYLdcM=",
-          "dev": true
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
-          }
-        },
         "lodash": {
           "version": "4.17.4",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
           "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        },
-        "lodash.assign": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-          "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
-          "dev": true
-        },
-        "lodash.clonedeep": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-          "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-          "dev": true
-        },
-        "longest": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
           "dev": true
         },
         "loose-envify": {
@@ -7860,88 +7994,6 @@
             "js-tokens": "3.0.2"
           }
         },
-        "loud-rejection": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-          "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-          "dev": true,
-          "requires": {
-            "currently-unhandled": "0.4.1",
-            "signal-exit": "3.0.2"
-          }
-        },
-        "lru-cache": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-          "dev": true,
-          "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
-          }
-        },
-        "map-obj": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-          "dev": true
-        },
-        "matcher-collection": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.5.tgz",
-          "integrity": "sha512-nUCmzKipcJEwYsBVAFh5P+d7JBuhJaW1xs85Hara9xuMLqtCVUrW6DSC0JVIkluxEH2W45nPBM/wjHtBXa/tYA==",
-          "dev": true,
-          "requires": {
-            "minimatch": "3.0.4"
-          }
-        },
-        "meow": {
-          "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-          "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-          "dev": true,
-          "requires": {
-            "camelcase-keys": "2.1.0",
-            "decamelize": "1.2.0",
-            "loud-rejection": "1.6.0",
-            "map-obj": "1.0.1",
-            "minimist": "1.2.0",
-            "normalize-package-data": "2.4.0",
-            "object-assign": "4.1.1",
-            "read-pkg-up": "1.0.1",
-            "redent": "1.0.0",
-            "trim-newlines": "1.0.0"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-              "dev": true
-            }
-          }
-        },
-        "merge": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-          "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
-          "dev": true
-        },
-        "mime-db": {
-          "version": "1.30.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-          "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.17",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-          "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
-          "dev": true,
-          "requires": {
-            "mime-db": "1.30.0"
-          }
-        },
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -7949,21 +8001,6 @@
           "dev": true,
           "requires": {
             "brace-expansion": "1.1.8"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
           }
         },
         "mktemp": {
@@ -7978,116 +8015,6 @@
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
-        "nan": {
-          "version": "2.8.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-          "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
-          "dev": true
-        },
-        "node-gyp": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
-          "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
-          "dev": true,
-          "requires": {
-            "fstream": "1.0.11",
-            "glob": "7.1.2",
-            "graceful-fs": "4.1.11",
-            "minimatch": "3.0.4",
-            "mkdirp": "0.5.1",
-            "nopt": "3.0.6",
-            "npmlog": "4.1.2",
-            "osenv": "0.1.4",
-            "request": "2.83.0",
-            "rimraf": "2.6.2",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "which": "1.3.0"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "5.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-              "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-              "dev": true
-            }
-          }
-        },
-        "node-sass": {
-          "version": "3.13.1",
-          "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.13.1.tgz",
-          "integrity": "sha1-ckD7v/I5YwS0IjUn7TAgWJwAT8I=",
-          "dev": true,
-          "requires": {
-            "async-foreach": "0.1.3",
-            "chalk": "1.1.3",
-            "cross-spawn": "3.0.1",
-            "gaze": "1.1.2",
-            "get-stdin": "4.0.1",
-            "glob": "7.1.2",
-            "in-publish": "2.0.0",
-            "lodash.assign": "4.2.0",
-            "lodash.clonedeep": "4.5.0",
-            "meow": "3.7.0",
-            "mkdirp": "0.5.1",
-            "nan": "2.8.0",
-            "node-gyp": "3.6.2",
-            "npmlog": "4.1.2",
-            "request": "2.83.0",
-            "sass-graph": "2.2.4"
-          }
-        },
-        "nopt": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-          "dev": true,
-          "requires": {
-            "abbrev": "1.1.1"
-          }
-        },
-        "normalize-package-data": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-          "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-          "dev": true,
-          "requires": {
-            "hosted-git-info": "2.5.0",
-            "is-builtin-module": "1.0.0",
-            "semver": "5.4.1",
-            "validate-npm-package-license": "3.0.1"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-          "dev": true,
-          "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        },
         "once": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -8097,132 +8024,10 @@
             "wrappy": "1.0.2"
           }
         },
-        "os-homedir": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-          "dev": true
-        },
-        "os-locale": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-          "dev": true,
-          "requires": {
-            "lcid": "1.0.0"
-          }
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-          "dev": true
-        },
-        "osenv": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-          "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
-          "dev": true,
-          "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
-          }
-        },
-        "output-file-sync": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
-          "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "mkdirp": "0.5.1",
-            "object-assign": "4.1.1"
-          }
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "1.3.1"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
-        },
         "path-is-absolute": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-          "dev": true
-        },
-        "path-parse": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-          "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
-          "dev": true
-        },
-        "path-posix": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/path-posix/-/path-posix-1.0.0.tgz",
-          "integrity": "sha1-BrJhE/Vr6rBCVFojv6iAA8ysJg8=",
-          "dev": true
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "performance-now": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-          "dev": true
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-          "dev": true
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-          "dev": true,
-          "requires": {
-            "pinkie": "2.0.4"
-          }
-        },
-        "private": {
-          "version": "0.1.8",
-          "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-          "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
-          "dev": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
           "dev": true
         },
         "promise-map-series": {
@@ -8233,30 +8038,6 @@
           "requires": {
             "rsvp": "3.6.2"
           }
-        },
-        "pseudomap": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-          "dev": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
-        },
-        "q": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-          "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
-          "dev": true
-        },
-        "qs": {
-          "version": "6.5.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
-          "dev": true
         },
         "quick-temp": {
           "version": "0.1.8",
@@ -8269,216 +8050,11 @@
             "underscore.string": "3.3.4"
           }
         },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "dev": true,
-          "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "recast": {
-          "version": "0.10.33",
-          "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
-          "integrity": "sha1-lCgI96oBbx+nFCxGHX5XBKqo1pc=",
-          "dev": true,
-          "requires": {
-            "ast-types": "0.8.12",
-            "esprima-fb": "15001.1001.0-dev-harmony-fb",
-            "private": "0.1.8",
-            "source-map": "0.5.7"
-          },
-          "dependencies": {
-            "ast-types": {
-              "version": "0.8.12",
-              "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz",
-              "integrity": "sha1-oNkOQ1G7iHcWyD/WN+v4GK9K38w=",
-              "dev": true
-            }
-          }
-        },
-        "redent": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-          "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-          "dev": true,
-          "requires": {
-            "indent-string": "2.1.0",
-            "strip-indent": "1.0.1"
-          }
-        },
-        "regenerate": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-          "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
-          "dev": true
-        },
-        "regenerator": {
-          "version": "0.8.40",
-          "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
-          "integrity": "sha1-oORXxY69uuV1yfjNdRJ+k3VkNdg=",
-          "dev": true,
-          "requires": {
-            "commoner": "0.10.8",
-            "defs": "1.1.1",
-            "esprima-fb": "15001.1001.0-dev-harmony-fb",
-            "private": "0.1.8",
-            "recast": "0.10.33",
-            "through": "2.3.8"
-          }
-        },
         "regenerator-runtime": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
           "dev": true
-        },
-        "regexpu": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
-          "integrity": "sha1-5TTcmRqeWEYFDJjebX3UpVyeoW0=",
-          "dev": true,
-          "requires": {
-            "esprima": "2.7.3",
-            "recast": "0.10.33",
-            "regenerate": "1.3.3",
-            "regjsgen": "0.2.0",
-            "regjsparser": "0.1.5"
-          },
-          "dependencies": {
-            "esprima": {
-              "version": "2.7.3",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-              "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-              "dev": true
-            }
-          }
-        },
-        "regjsgen": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-          "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
-          "dev": true
-        },
-        "regjsparser": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-          "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-          "dev": true,
-          "requires": {
-            "jsesc": "0.5.0"
-          },
-          "dependencies": {
-            "jsesc": {
-              "version": "0.5.0",
-              "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-              "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-              "dev": true
-            }
-          }
-        },
-        "repeat-string": {
-          "version": "1.6.1",
-          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-          "dev": true
-        },
-        "repeating": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-          "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-          "dev": true,
-          "requires": {
-            "is-finite": "1.0.2"
-          }
-        },
-        "request": {
-          "version": "2.83.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-          "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
-          "dev": true,
-          "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.1",
-            "har-validator": "5.0.3",
-            "hawk": "6.0.2",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.1",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.1.0"
-          }
-        },
-        "require-directory": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-          "dev": true
-        },
-        "require-main-filename": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-          "dev": true
-        },
-        "resolve": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-          "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
-          "dev": true,
-          "requires": {
-            "path-parse": "1.0.5"
-          }
-        },
-        "right-align": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-          "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-          "dev": true,
-          "requires": {
-            "align-text": "0.1.4"
-          }
         },
         "rimraf": {
           "version": "2.6.2",
@@ -8495,196 +8071,25 @@
           "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
           "dev": true
         },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true
-        },
-        "sass-graph": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
-          "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
-          "dev": true,
-          "requires": {
-            "glob": "7.1.2",
-            "lodash": "4.17.4",
-            "scss-tokenizer": "0.2.3",
-            "yargs": "7.1.0"
-          }
-        },
-        "scss-tokenizer": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
-          "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
-          "dev": true,
-          "requires": {
-            "js-base64": "2.4.0",
-            "source-map": "0.4.4"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.4.4",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-              "dev": true,
-              "requires": {
-                "amdefine": "1.0.1"
-              }
-            }
-          }
-        },
         "semver": {
           "version": "5.4.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
           "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
           "dev": true
         },
-        "set-blocking": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-          "dev": true
-        },
-        "shebang-regex": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-          "dev": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-          "dev": true
-        },
-        "simple-fmt": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz",
-          "integrity": "sha1-GRv1ZqWeZTBILLJatTtKjchcOms=",
-          "dev": true
-        },
-        "simple-is": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz",
-          "integrity": "sha1-Krt1qt453rXMgVzhDmGRFkhQuvA=",
-          "dev": true
-        },
-        "slash": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-          "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-          "dev": true
-        },
-        "sntp": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-          "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+        "silent-error": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/silent-error/-/silent-error-1.1.0.tgz",
+          "integrity": "sha1-IglwbxyFCp8dENDYQJGLRvJuG8k=",
           "dev": true,
           "requires": {
-            "hoek": "4.2.0"
+            "debug": "2.6.9"
           }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        },
-        "source-map-support": {
-          "version": "0.4.18",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-          "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-          "dev": true,
-          "requires": {
-            "source-map": "0.5.7"
-          }
-        },
-        "spdx-correct": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-          "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-          "dev": true,
-          "requires": {
-            "spdx-license-ids": "1.2.2"
-          }
-        },
-        "spdx-expression-parse": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-          "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
-          "dev": true
-        },
-        "spdx-license-ids": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-          "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
-          "dev": true
         },
         "sprintf-js": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
           "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw=",
-          "dev": true
-        },
-        "sshpk": {
-          "version": "1.13.1",
-          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-          "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-          "dev": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "stable": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.6.tgz",
-          "integrity": "sha1-kQ9dKu17Ugxud3SZwfMuE5/eyxA=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "stringmap": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz",
-          "integrity": "sha1-VWwTeyWPlCuHdvWy71gqoGnX0bE=",
-          "dev": true
-        },
-        "stringset": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz",
-          "integrity": "sha1-7yWcTjSTRDd/zRyRPdLoSMnAQrU=",
-          "dev": true
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
           "dev": true
         },
         "strip-ansi": {
@@ -8705,15 +8110,6 @@
             "is-utf8": "0.2.1"
           }
         },
-        "strip-indent": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-          "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "4.0.1"
-          }
-        },
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
@@ -8726,83 +8122,11 @@
           "integrity": "sha1-yr5h4AEMHAI8Fzsl7lEIs39LSqM=",
           "dev": true
         },
-        "tar": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-          "dev": true,
-          "requires": {
-            "block-stream": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
-          }
-        },
-        "textextensions": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.1.0.tgz",
-          "integrity": "sha1-G+DcKg3CRNRL6KCa9qha+5PE28M=",
-          "dev": true
-        },
-        "through": {
-          "version": "2.3.8",
-          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-          "dev": true
-        },
         "to-fast-properties": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
           "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
           "dev": true
-        },
-        "tough-cookie": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-          "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
-          "dev": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "trim-newlines": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-          "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-          "dev": true
-        },
-        "trim-right": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-          "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-          "dev": true
-        },
-        "try-resolve": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz",
-          "integrity": "sha1-z95vq9ctY+V5fPqrhzq76OcA6RI=",
-          "dev": true
-        },
-        "tryor": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz",
-          "integrity": "sha1-gUXkynyv9ArN48z5Rui4u3W0Fys=",
-          "dev": true
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-          "dev": true,
-          "optional": true
         },
         "underscore.string": {
           "version": "3.3.4",
@@ -8814,170 +8138,17 @@
             "util-deprecate": "1.0.2"
           }
         },
-        "user-home": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-          "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
-          "dev": true
-        },
-        "username-sync": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/username-sync/-/username-sync-1.0.1.tgz",
-          "integrity": "sha1-HN6H7vz5S4gimE2Ti6K3l0Jtrh8=",
-          "dev": true
-        },
         "util-deprecate": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true
         },
-        "uuid": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
-          "dev": true
-        },
-        "validate-npm-package-license": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-          "dev": true,
-          "requires": {
-            "spdx-correct": "1.0.2",
-            "spdx-expression-parse": "1.0.4"
-          }
-        },
-        "verror": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-          "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "core-util-is": "1.0.2",
-            "extsprintf": "1.3.0"
-          }
-        },
-        "walk-sync": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.2.tgz",
-          "integrity": "sha512-FMB5VqpLqOCcqrzA9okZFc0wq0Qbmdm396qJxvQZhDpyu0W95G9JCmp74tx7iyYnyOcBtUuKJsgIKAqjozvmmQ==",
-          "dev": true,
-          "requires": {
-            "ensure-posix-path": "1.0.2",
-            "matcher-collection": "1.0.5"
-          }
-        },
-        "which": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-          "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-          "dev": true,
-          "requires": {
-            "isexe": "2.0.0"
-          }
-        },
-        "which-module": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-          "dev": true
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-          "dev": true,
-          "requires": {
-            "string-width": "1.0.2"
-          }
-        },
-        "window-size": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-          "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
-          "dev": true
-        },
-        "wordwrap": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "dev": true
-        },
-        "wrap-ansi": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-          "dev": true,
-          "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1"
-          }
-        },
         "wrappy": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
-        },
-        "y18n": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-          "dev": true
-        },
-        "yallist": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-          "dev": true
-        },
-        "yargs": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
-          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
-          "dev": true,
-          "requires": {
-            "camelcase": "3.0.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "5.0.0"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-              "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-              "dev": true
-            }
-          }
-        },
-        "yargs-parser": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
-          "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
-          "dev": true,
-          "requires": {
-            "camelcase": "3.0.0"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-              "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-              "dev": true
-            }
-          }
         }
       }
     },
@@ -9239,6 +8410,15 @@
           "integrity": "sha1-ry5366XcsNd/MwjTpv19NFD25Tc=",
           "dev": true
         },
+        "ember-cli-version-checker": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
+          "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
+          "dev": true,
+          "requires": {
+            "semver": "5.4.1"
+          }
+        },
         "exists-sync": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/exists-sync/-/exists-sync-0.0.3.tgz",
@@ -9270,6 +8450,12 @@
           "version": "3.6.2",
           "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
           "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
           "dev": true
         }
       }
@@ -9342,6 +8528,42 @@
       "requires": {
         "ember-cli-babel": "6.10.0",
         "ember-qunit": "3.1.0"
+      }
+    },
+    "ember-cli-sass": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-sass/-/ember-cli-sass-6.2.0.tgz",
+      "integrity": "sha1-4fgSiWeOHiLZz52/f6LedqDemi8=",
+      "dev": true,
+      "requires": {
+        "broccoli-funnel": "1.2.0",
+        "broccoli-merge-trees": "1.2.4",
+        "broccoli-sass-source-maps": "2.1.0",
+        "ember-cli-version-checker": "1.3.1",
+        "merge": "1.2.0"
+      },
+      "dependencies": {
+        "ember-cli-version-checker": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
+          "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
+          "dev": true,
+          "requires": {
+            "semver": "5.4.1"
+          }
+        },
+        "merge": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+          "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+          "dev": true
+        }
       }
     },
     "ember-cli-shims": {
@@ -9774,10 +8996,11 @@
       }
     },
     "ember-cli-version-checker": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-      "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz",
+      "integrity": "sha512-ssiNyVTp+PphroFum8guHX9py4xU1PCxkRYgb25NxumgjpKTPjhkgTfpRRKXlIQe+/wVMmhf+Uv6w9vSLZKWKQ==",
       "requires": {
+        "resolve": "1.5.0",
         "semver": "5.4.1"
       },
       "dependencies": {
@@ -9960,7 +9183,8 @@
     "ember-rfc176-data": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.1.tgz",
-      "integrity": "sha512-u+W5rUvYO7xyKJjiPuCM7bIAvFyPwPTJ66fOZz1xuCv3AyReI9Oev5oOADOO6YJZk+vEn0xWiZ9N6zSf8WU7Fg=="
+      "integrity": "sha512-u+W5rUvYO7xyKJjiPuCM7bIAvFyPwPTJ66fOZz1xuCv3AyReI9Oev5oOADOO6YJZk+vEn0xWiZ9N6zSf8WU7Fg==",
+      "dev": true
     },
     "ember-router-generator": {
       "version": "1.2.3",
@@ -11258,6 +10482,16 @@
       "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
       "dev": true
     },
+    "foundation-sites": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/foundation-sites/-/foundation-sites-6.4.3.tgz",
+      "integrity": "sha1-6onrWZut9vA91SbFHwC9uUKoRPY=",
+      "dev": true,
+      "requires": {
+        "jquery": "3.2.1",
+        "what-input": "4.3.1"
+      }
+    },
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -11289,6 +10523,78 @@
           "requires": {
             "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
           }
+        }
+      }
+    },
+    "fs-tree-diff": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.7.tgz",
+      "integrity": "sha512-dJwDX6NBH7IfdfFjZAdHCZ6fIKc8LwR7kzqUhYRFJuX4g9ctG/7cuqJuwegGQsyLEykp6Z4krq+yIFMQlt7d9Q==",
+      "dev": true,
+      "requires": {
+        "heimdalljs-logger": "0.1.9",
+        "object-assign": "4.1.1",
+        "path-posix": "1.0.0",
+        "symlink-or-copy": "1.1.8"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "heimdalljs": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.2.5.tgz",
+          "integrity": "sha1-aqVDCO7nk7ZCz/nPlHgURfN3MKw=",
+          "dev": true,
+          "requires": {
+            "rsvp": "3.2.1"
+          }
+        },
+        "heimdalljs-logger": {
+          "version": "0.1.9",
+          "resolved": "https://registry.npmjs.org/heimdalljs-logger/-/heimdalljs-logger-0.1.9.tgz",
+          "integrity": "sha1-12raTkW3u294b8nAEKaOsuL68XY=",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "heimdalljs": "0.2.5"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true
+        },
+        "path-posix": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/path-posix/-/path-posix-1.0.0.tgz",
+          "integrity": "sha1-BrJhE/Vr6rBCVFojv6iAA8ysJg8=",
+          "dev": true
+        },
+        "rsvp": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
+          "integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo=",
+          "dev": true
+        },
+        "symlink-or-copy": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.1.8.tgz",
+          "integrity": "sha1-yr5h4AEMHAI8Fzsl7lEIs39LSqM=",
+          "dev": true
         }
       }
     },
@@ -12341,6 +11647,12 @@
         }
       }
     },
+    "globals": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "dev": true
+    },
     "globby": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
@@ -12518,6 +11830,166 @@
       "version": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
+    "hash-for-dep": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
+      "integrity": "sha512-NE//rDaCFpWHViw30YM78OAGBShU+g4dnUGY3UWGyEzPOGYg/ptOjk32nEc+bC1xz+RfK5UIs6lOL6eQdrV4Ow==",
+      "dev": true,
+      "requires": {
+        "broccoli-kitchen-sink-helpers": "0.3.1",
+        "heimdalljs": "0.2.5",
+        "heimdalljs-logger": "0.1.9",
+        "resolve": "1.5.0"
+      },
+      "dependencies": {
+        "balanced-match": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+          "dev": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "broccoli-kitchen-sink-helpers": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.3.1.tgz",
+          "integrity": "sha1-d8fBgZS5ZkFj7E/O4nk0RJJuDAY=",
+          "dev": true,
+          "requires": {
+            "glob": "5.0.15",
+            "mkdirp": "0.5.1"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "heimdalljs": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.2.5.tgz",
+          "integrity": "sha1-aqVDCO7nk7ZCz/nPlHgURfN3MKw=",
+          "dev": true,
+          "requires": {
+            "rsvp": "3.2.1"
+          }
+        },
+        "heimdalljs-logger": {
+          "version": "0.1.9",
+          "resolved": "https://registry.npmjs.org/heimdalljs-logger/-/heimdalljs-logger-0.1.9.tgz",
+          "integrity": "sha1-12raTkW3u294b8nAEKaOsuL68XY=",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "heimdalljs": "0.2.5"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "dev": true
+        },
+        "rsvp": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
+          "integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo=",
+          "dev": true
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "dev": true
+        }
+      }
+    },
     "hawk": {
       "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
@@ -12585,6 +12057,30 @@
     "hoek": {
       "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+    },
+    "home-or-tmp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      },
+      "dependencies": {
+        "os-homedir": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+          "dev": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+          "dev": true
+        }
+      }
     },
     "homedir-polyfill": {
       "version": "1.0.1",
@@ -13011,6 +12507,12 @@
       "integrity": "sha1-fPLLaYGWaEeQNQ0MTKB/Su2ewX4=",
       "dev": true
     },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
     "js-yaml": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
@@ -13069,6 +12571,12 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
       "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+      "dev": true
+    },
+    "json5": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
     "jsonfile": {
@@ -14593,6 +14101,12 @@
       "integrity": "sha1-xDjKLKM+OSdnHbSracDlL5NqTw8=",
       "dev": true
     },
+    "private": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+      "dev": true
+    },
     "process-nextick-args": {
       "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
@@ -14884,6 +14398,7 @@
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
       "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
@@ -14894,6 +14409,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+          "dev": true,
           "requires": {
             "core-js": "2.5.1",
             "regenerator-runtime": "0.11.0"
@@ -14903,6 +14419,7 @@
           "version": "6.26.0",
           "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
           "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+          "dev": true,
           "requires": {
             "babel-runtime": "6.26.0",
             "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
@@ -14913,22 +14430,26 @@
         "core-js": {
           "version": "2.5.1",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+          "dev": true
         },
         "lodash": {
           "version": "4.17.4",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
         },
         "private": {
           "version": "0.1.8",
           "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-          "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+          "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+          "dev": true
         },
         "regenerator-runtime": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+          "dev": true
         }
       }
     },
@@ -14945,6 +14466,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+      "dev": true,
       "requires": {
         "regenerate": "1.3.3",
         "regjsgen": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
@@ -14954,7 +14476,8 @@
         "regenerate": {
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-          "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
+          "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
+          "dev": true
         }
       }
     },
@@ -15044,6 +14567,21 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
+    },
+    "resolve": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+      "requires": {
+        "path-parse": "1.0.5"
+      },
+      "dependencies": {
+        "path-parse": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+          "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+        }
+      }
     },
     "resolve-dir": {
       "version": "0.1.1",
@@ -15464,6 +15002,23 @@
       "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
       "requires": {
         "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+      }
+    },
+    "source-map-support": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.7"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
       }
     },
     "source-map-url": {
@@ -16004,6 +15559,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-sync/-/tree-sync-1.2.2.tgz",
       "integrity": "sha1-LPdrhYn1n/7bWNtaOsfLAT0BWLc=",
+      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "fs-tree-diff": "0.5.7",
@@ -16016,6 +15572,7 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
           "requires": {
             "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
           }
@@ -16024,6 +15581,7 @@
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.7.tgz",
           "integrity": "sha512-dJwDX6NBH7IfdfFjZAdHCZ6fIKc8LwR7kzqUhYRFJuX4g9ctG/7cuqJuwegGQsyLEykp6Z4krq+yIFMQlt7d9Q==",
+          "dev": true,
           "requires": {
             "heimdalljs-logger": "https://registry.npmjs.org/heimdalljs-logger/-/heimdalljs-logger-0.1.9.tgz",
             "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -16035,6 +15593,7 @@
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.5.tgz",
           "integrity": "sha512-nUCmzKipcJEwYsBVAFh5P+d7JBuhJaW1xs85Hara9xuMLqtCVUrW6DSC0JVIkluxEH2W45nPBM/wjHtBXa/tYA==",
+          "dev": true,
           "requires": {
             "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
           }
@@ -16043,6 +15602,7 @@
           "version": "0.2.7",
           "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.7.tgz",
           "integrity": "sha1-tJvk7mhnZXrrc2l4tWop0Q+jmWk=",
+          "dev": true,
           "requires": {
             "ensure-posix-path": "https://registry.npmjs.org/ensure-posix-path/-/ensure-posix-path-1.0.2.tgz",
             "matcher-collection": "1.0.5"
@@ -16291,6 +15851,12 @@
       "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
       "dev": true
     },
+    "what-input": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/what-input/-/what-input-4.3.1.tgz",
+      "integrity": "sha512-7KD71RWNRWI9M08shZ8+n/2UjO5amwsG9PMSXWz0iIlH8H2DVbHE8Z2tW1RqQa0kIwdeqdUIffFz7crDfkcbAw==",
+      "dev": true
+    },
     "which": {
       "version": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
@@ -16319,6 +15885,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.0.tgz",
       "integrity": "sha512-JP5DpviEV84zDmz13QnD4FfRjZBjnTOYY2O4pGgxtlqLh47WOzQFHm8o17TE5OSfcDoKC6vHSrN4yPju93DW0Q==",
+      "dev": true,
       "requires": {
         "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "broccoli-funnel": "^1.0.0",
     "broccoli-merge-trees": "^1.1.0",
     "broccoli-sass-source-maps": "^2.1.0",
-    "ember-cli-version-checker": "^1.0.2"
+    "ember-cli-version-checker": "^2.1.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
@@ -34,7 +34,7 @@
     "ember-cli-babel": "^6.6.0",
     "ember-cli-dependency-checker": "^2.0.0",
     "ember-cli-eslint": "^4.2.1",
-    "ember-cli-foundation-6-sass": "0.0.17",
+    "ember-cli-foundation-6-sass": "0.0.24",
     "ember-cli-htmlbars": "^2.0.1",
     "ember-cli-htmlbars-inline-precompile": "^1.0.0",
     "ember-cli-inject-live-reload": "^1.4.1",

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -1,5 +1,5 @@
 @import 'spinkit';
-@import 'foundation';
+@import 'foundation-sites/foundation';
 
 @include foundation-typography;
 


### PR DESCRIPTION
Resolves #174 by updating ember-cli-version-checker to v2.1 and updating version checking syntax in index.js. 

This is turn broke the usage of ember-cli-foundation-6-sass, as v0.0.17 ~~also uses~~ _has a dependency on ember-cli-htmlbars@^1.1.1 which uses_ the old version-checker syntax. That package was then updated to v0.0.24, however this includes an update to Foundation to 6.3+ which affects how the Foundation styles are imported (see also #151). It seems like there's some controversy about the changes in Foundation 6.3 but it does not seem to be practical to resolve this issue without updating ember-cli-foundation-6-sass.