### PR TITLE
Allow for passing generated files from the styles tree through to dist/

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ var app = new EmberApp({
 - `onlyIncluded`: true/false whether to use only what is in `app/styles` and `includePaths`. This may helps with performance, particularly when using NPM linked modules
 - `sourceMap`: controls whether to generate sourceMaps, defaults to `true` in development. The sourceMap file will be saved to `options.outputFile + '.map'`
 - `extension`: specifies the file extension for the input files, defaults to `scss`. Set to `sass` if you want to use `.sass` instead.
+- `passthrough`: an optional hash of [broccoli-funnel](https://github.com/broccolijs/broccoli-funnel) configuration for files from the styles tree to be passed through to `dist`
 - `nodeSass`: Allows a different version of [node-sass](https://www.npmjs.com/package/node-sass) to be used (see below)
 - See [broccoli-sass-source-maps](https://github.com/aexmachina/broccoli-sass-source-maps) for a list of other supported options.
 

--- a/index.js
+++ b/index.js
@@ -38,6 +38,10 @@ SASSPlugin.prototype.toTree = function(tree, inputPath, outputPath, inputOptions
     return new SassCompiler(inputTrees, input, output, options);
   });
 
+  if (options.passthrough) {
+    trees.push(new Funnel(tree, options.passthrough));
+  }
+
   return mergeTrees(trees);
 };
 

--- a/testem.js
+++ b/testem.js
@@ -12,11 +12,14 @@ module.exports = {
     Chrome: {
       mode: 'ci',
       args: [
+        // --no-sandbox is needed when running Chrome inside a container
+        process.env.TRAVIS ? '--no-sandbox' : null,
+
         '--disable-gpu',
         '--headless',
         '--remote-debugging-port=0',
         '--window-size=1440,900'
-      ]
+      ].filter(Boolean)
     }
   }
 };


### PR DESCRIPTION
This PR adds a `passthrough` option that allows for artifacts produced earlier in styles processing to be emitted into the final output in `dist`.

@chriskrycho can offer some details on the situation he ran into where this would be useful to have.