### PR TITLE
Fall back to host config in engines

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,11 +74,17 @@ module.exports = {
     var env  = process.env.EMBER_ENV;
     var envConfig = this.project.config(env).sassOptions;
 
+    var app = this.app;
+    var parent = this.parent;
+    var hostApp = typeof this._findHost === 'function' ? this._findHost() : undefined;
+
     // *Either* use the options for an addon which is consuming this, *or* for
     // an app which is consuming this, but never *both* at the same time. The
     // special case here is when testing an addon.
-    var options = (this.app && this.app.options && this.app.options.sassOptions)
-      || (this.parent && this.parent.options && this.parent.options.sassOptions)
+    // In lazy loading engines, the host might be different from the parent, so we fall back to that one
+    var options = (app && app.options && app.options.sassOptions)
+      || (parent && parent.options && parent.options.sassOptions)
+      || (hostApp && hostApp.options && hostApp.options.sassOptions)
       || {};
 
     if (envConfig) {


### PR DESCRIPTION
After upgrading to ember-cli-sass@10.0.0, our build stopped working.
The reason was that we import partials in our lazy loaded engines.

So we have an addon with a file `app/styles/variables.scss`.
This addon is installed in the lazy loaded engine, and there used like this:

```scss
// addon/styles/addon.scss

@import 'variables.scss';

// custom styles for the engine...
```

This used to work fine, but started throwing an error that `variables` could not be imported.
After digging around, the issue seems to be that the `includePaths` are not correctly available inside of the engine.

This PR ensures that ember-cli-sass falls back to using the host app's configuration (loaded through `this._findHost()`, which is available since ember-cli 2.7 I believe), if no other is found.

This change fixed our application build.